### PR TITLE
Fixes error thrown if data's initial value is null

### DIFF
--- a/vue-rx.js
+++ b/vue-rx.js
@@ -21,7 +21,7 @@
           var raw = dataFn()
           Object.keys(raw).forEach(function (key) {
             var val = raw[key]
-            if (val.subscribe instanceof Function) {
+            if (val && val.subscribe instanceof Function) {
               raw[key] = null
               ;(self._rxHandles || (self._rxHandles = []))
                 .push(val.subscribe(function (value) {


### PR DESCRIPTION
Or undefined. To reproduce/test this fix, simply try creating a component with a data property like so: `{ data: function() { return { something: null }; } }`