### PR TITLE
subs can also be function, allowing later execution

### DIFF
--- a/vue-rx.js
+++ b/vue-rx.js
@@ -34,6 +34,9 @@
         vm._obSubscriptions = []
         Object.keys(obs).forEach(function (key) {
           defineReactive(vm, key, undefined)
+          if (typeof obs[key] === 'function') {
+            obs[key] = obs[key].call(vm)
+          }
           var ob = vm.$subscriptions[key] = obs[key]
           if (!ob || typeof ob.subscribe !== 'function') {
             warn(


### PR DESCRIPTION
When writing `subscriptions` we sometimes need to use `props` to generate the observable:

```
props: ['id'],
subscriptions: {
  a: SomeObservableGenerator(this.id)
}
```
But currently `SomeObservableGenerator(this.id)` is executed as soon as this vue/js file is required (in webpack), and at that time `this.id` does not exist yet, so the code fails to run.

This PR allows `a` to be a function that returns an observable, so we can make it this way:
```
props: ['id'],
subscriptions: {
  a: function () {
    SomeObservableGenerator(this.id)
  }
}
```
Now the function is run during `created`, when `this.id` already exists, so the code runs OK.

BTW it can only work for `props` since `props` does not change. If `data` or `computed` are used in the function, only the initial value is used and the observable would not be unsubscribed and resubscribed when `data`/`computed` value is renewed. 
