### PR TITLE
support create dom event stream from component $el

### DIFF
--- a/vue-rx.js
+++ b/vue-rx.js
@@ -112,7 +112,7 @@
       var doc = document.documentElement
       var obs$ = Rx.Observable.create(function (observer) {
         function listener (e) {
-          if (vm.$el && vm.$el.querySelector(selector) === e.target) {
+          if (vm.$el && (selector === vm.$el ? vm.$el : vm.$el.querySelector(selector)) === e.target) {
             observer.next(e)
           }
         }


### PR DESCRIPTION
Need to listen from component root element, when `template` is just like `<button ...`

This patch let you do

```
vm.$fromDOMEvent(vm.$el, 'click');
```

An alternative solution is let first argument be `null`.