### PR TITLE
fix querySelector

### DIFF
--- a/vue-rx.js
+++ b/vue-rx.js
@@ -112,8 +112,12 @@
       var doc = document.documentElement
       var obs$ = Rx.Observable.create(function (observer) {
         function listener (e) {
-          if (vm.$el && (selector === null ? vm.$el : vm.$el.querySelector(selector)) === e.target) {
-            observer.next(e)
+          if (!vm.$el) return;
+          if (selector === null && vm.$el === e.target) return observer.next(e)
+          var els = vm.$el.querySelectorAll(selector);
+          var el = e.target;
+          for (var i = 0, len = els.length; i < len; i++) {
+            if (els[i] === el) return observer.next(e)
           }
         }
         doc.addEventListener(event, listener)


### PR DESCRIPTION
replace `vm.$el.querySelector` with `vm.$el.querySelectorAll`.
even if `selector` match many elements, `querySelector` return the first one only.

---

`querySelector` example: http://output.jsbin.com/rociqow
fixed by `querySelectorAll`: http://output.jsbin.com/gaditaq

```js
subscriptions() {
    return {
        html: this.$fromDOMEvent('li', 'click').pluck('target', 'innerHTML')
    };
}
```