### PR TITLE
add 'fromEvent' options

### DIFF
--- a/example/counter.html
+++ b/example/counter.html
@@ -10,6 +10,9 @@
   <!-- simple usage -->
   <button v-stream:click="plus$">Add on Click</button>
 
+
+  <button v-stream:click="{ subject: plus$, data: minusDelta1, options:{once:true} }">Add on Click (Option once:true)</button>
+
   <!-- you can also stream to the same subject with different events/data -->
   <button
     v-stream:click="{ subject: minus$, data: minusDelta1 }"

--- a/src/directives/stream.js
+++ b/src/directives/stream.js
@@ -21,11 +21,20 @@ export default {
         vnode.context
       )
       return
+    }else if(!Rx.Observable.fromEvent){
+      warn(
+        `No 'fromEvent' method on Observable class` +
+        `v-stream directive requires Rx.Observable.fromEvent method` +
+        `try import 'rxjs/add/observable/fromEvent' for ${streamName}`,
+        vnode.context
+      )
+      return
     }
 
     const subject = handle.subject
     const next = (subject.next || subject.onNext).bind(subject)
-    handle.subscription = Rx.Observable.fromEvent(el, event).subscribe(e => {
+    let fromEventArgs = handle.options ? [el, event, handle.options] : [el, event]
+    handle.subscription = Rx.Observable.fromEvent(...fromEventArgs).subscribe(e => {
       next({
         event: e,
         data: handle.data

--- a/src/directives/stream.js
+++ b/src/directives/stream.js
@@ -21,7 +21,7 @@ export default {
         vnode.context
       )
       return
-    }else if(!Rx.Observable.fromEvent){
+    } else if (!Rx.Observable.fromEvent) {
       warn(
         `No 'fromEvent' method on Observable class` +
         `v-stream directive requires Rx.Observable.fromEvent method` +

--- a/src/directives/stream.js
+++ b/src/directives/stream.js
@@ -23,9 +23,9 @@ export default {
       return
     } else if (!Rx.Observable.fromEvent) {
       warn(
-        `No 'fromEvent' method on Observable class` +
-        `v-stream directive requires Rx.Observable.fromEvent method` +
-        `try import 'rxjs/add/observable/fromEvent' for ${streamName}`,
+        `No 'fromEvent' method on Observable class. ` +
+        `v-stream directive requires Rx.Observable.fromEvent method. ` +
+        `Try import 'rxjs/add/observable/fromEvent' for ${streamName}`,
         vnode.context
       )
       return


### PR DESCRIPTION
1. Add support fromEvent Options; [Doc](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)
2. Add missing method 'fromEvent' warning;