### PR TITLE
Supporting RxJS v6 (still supports v5). "fromEvent" and "share" check…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4654,13 +4654,18 @@
       "dev": true
     },
     "rxjs": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.0.tgz",
-      "integrity": "sha512-vmvP5y/oJIJmXKHY36PIjVeI/46Sny6BMBa7/ou2zsNz1PiqU/Gtcz1GujnHz5Qlxncv+J9VlWmttnshqFj3Kg==",
+      "version": "6.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.0.0-beta.3.tgz",
+      "integrity": "sha512-Rkc4BDr75zsX4ozYOra9E0uAn8jDlnNvE7ISx/w6P7fkREmJH3Y0Zsz0FKRdo/AjWVzqytvjN1umHlTv/Ozayg==",
       "dev": true,
       "requires": {
-        "symbol-observable": "1.0.4"
+        "tslib": "1.9.0"
       }
+    },
+    "rxjs-compat": {
+      "version": "6.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/rxjs-compat/-/rxjs-compat-6.0.0-beta.1.tgz",
+      "integrity": "sha512-KfKSNhBStS1Vs/9ifOub430dTC4XUlPkPbbV7hexFX1+PmIF4RsW2LnHmSXiNfVPesdqRgiDvNZFkBMr4AqARA=="
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -4911,12 +4916,6 @@
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
-    "symbol-observable": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
-      "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=",
-      "dev": true
-    },
     "symbol-tree": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
@@ -5038,6 +5037,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
       "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+      "dev": true
+    },
+    "tslib": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
       "dev": true
     },
     "tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "rollup": "^0.50.0",
     "rollup-plugin-buble": "^0.16.0",
     "rollup-watch": "^4.3.1",
-    "rxjs": "^6.0.0-beta.3˝∏˝",
+    "rxjs": "^6.0.0-beta.3",
     "rxjs-compat": "^6.0.0-beta.1",
     "typescript": "^2.5.2",
     "vue": "^2.5.0"

--- a/package.json
+++ b/package.json
@@ -1,33 +1,30 @@
 {
   "name": "vue-rx",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "RxJS bindings for Vue",
   "main": "dist/vue-rx.js",
-  "files": [
-    "dist",
-    "types/*.d.ts"
-  ],
+  "files": ["dist", "types/*.d.ts"],
   "typings": "types/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue-rx.git"
+    "url":
+      "git+https://github.com/vuejs/vue-rx.git"
   },
-  "keywords": [
-    "vue",
-    "rx",
-    "rxjs"
-  ],
+  "keywords": ["vue", "rx", "rxjs"],
   "author": "Evan You",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/vuejs/vue-rx/issues"
+    "url":
+      "https://github.com/vuejs/vue-rx/issues"
   },
-  "homepage": "https://github.com/vuejs/vue-rx#readme",
+  "homepage":
+    "https://github.com/vuejs/vue-rx#readme",
   "scripts": {
     "dev": "rollup -c rollup.config.js -w",
     "build": "rollup -c rollup.config.js",
     "lint": "eslint src test example --fix",
-    "test": "npm run test:unit && npm run test:types",
+    "test":
+      "npm run test:unit && npm run test:types",
     "test:unit": "jest",
     "test:types": "tsc -p types/test",
     "dev:test": "jest --watch",
@@ -43,14 +40,13 @@
     "rollup": "^0.50.0",
     "rollup-plugin-buble": "^0.16.0",
     "rollup-watch": "^4.3.1",
-    "rxjs": "^5.2.0",
+    "rxjs": "^6.0.0-beta.3˝∏˝",
+    "rxjs-compat": "^6.0.0-beta.1",
     "typescript": "^2.5.2",
     "vue": "^2.5.0"
   },
   "eslintConfig": {
     "root": true,
-    "extends": [
-      "plugin:vue-libs/recommended"
-    ]
+    "extends": ["plugin:vue-libs/recommended"]
   }
 }

--- a/src/directives/stream.js
+++ b/src/directives/stream.js
@@ -1,4 +1,11 @@
-import { Rx, hasRx, isSubject, warn, getKey, unsub } from '../util'
+import {
+  Rx,
+  hasRx,
+  isSubject,
+  warn,
+  getKey,
+  unsub
+} from '../util'
 
 export default {
   // Example ./example/counter_dir.html
@@ -14,11 +21,17 @@ export default {
 
     if (isSubject(handle)) {
       handle = { subject: handle }
-    } else if (!handle || !isSubject(handle.subject)) {
+    } else if (
+      !handle ||
+      !isSubject(handle.subject)
+    ) {
       warn(
-        'Invalid Subject found in directive with key "' + streamName + '".' +
-        streamName + ' should be an instance of Rx.Subject or have the ' +
-        'type { subject: Rx.Subject, data: any }.',
+        'Invalid Subject found in directive with key "' +
+          streamName +
+          '".' +
+          streamName +
+          ' should be an instance of Rx.Subject or have the ' +
+          'type { subject: Rx.Subject, data: any }.',
         vnode.context
       )
       return
@@ -29,34 +42,50 @@ export default {
       prevent: e => e.preventDefault()
     }
 
-    var modifiersExists = Object.keys(modifiersFuncs).filter(
-        key => modifiers[key]
-    )
+    var modifiersExists = Object.keys(
+      modifiersFuncs
+    ).filter(key => modifiers[key])
 
     const subject = handle.subject
-    const next = (subject.next || subject.onNext).bind(subject)
+    const next = (
+      subject.next || subject.onNext
+    ).bind(subject)
 
-    if (!modifiers.native && vnode.componentInstance) {
-      handle.subscription = vnode.componentInstance.$eventToObservable(event).subscribe(e => {
-        modifiersExists.forEach(mod => modifiersFuncs[mod](e))
-        next({
-          event: e,
-          data: handle.data
+    if (
+      !modifiers.native &&
+      vnode.componentInstance
+    ) {
+      handle.subscription = vnode.componentInstance
+        .$eventToObservable(event)
+        .subscribe(e => {
+          modifiersExists.forEach(mod =>
+            modifiersFuncs[mod](e)
+          )
+          next({
+            event: e,
+            data: handle.data
+          })
         })
-      })
     } else {
-      if (!Rx.Observable.fromEvent) {
+      const fromEvent =
+        Rx.fromEvent || Rx.Observable.fromEvent
+      if (!fromEvent) {
         warn(
-          `No 'fromEvent' method on Observable class. ` +
-          `v-stream directive requires Rx.Observable.fromEvent method. ` +
-          `Try import 'rxjs/add/observable/fromEvent' for ${streamName}`,
+          `Please import 'rxjs/operators/fromEvent' and pass to the Vue.use plugin install` +
+            `v-stream directive requires Rx.Observable.fromEvent method. `,
           vnode.context
         )
         return
       }
-      const fromEventArgs = handle.options ? [el, event, handle.options] : [el, event]
-      handle.subscription = Rx.Observable.fromEvent(...fromEventArgs).subscribe(e => {
-        modifiersExists.forEach(mod => modifiersFuncs[mod](e))
+      const fromEventArgs = handle.options
+        ? [el, event, handle.options]
+        : [el, event]
+      handle.subscription = fromEvent(
+        ...fromEventArgs
+      ).subscribe(e => {
+        modifiersExists.forEach(mod =>
+          modifiersFuncs[mod](e)
+        )
         next({
           event: e,
           data: handle.data
@@ -65,21 +94,30 @@ export default {
 
       // store handle on element with a unique key for identifying
       // multiple v-stream directives on the same node
-      ;(el._rxHandles || (el._rxHandles = {}))[getKey(binding)] = handle
+      ;(el._rxHandles || (el._rxHandles = {}))[
+        getKey(binding)
+      ] = handle
     }
   },
 
   update (el, binding) {
     const handle = binding.value
-    const _handle = el._rxHandles && el._rxHandles[getKey(binding)]
-    if (_handle && handle && isSubject(handle.subject)) {
+    const _handle =
+      el._rxHandles &&
+      el._rxHandles[getKey(binding)]
+    if (
+      _handle &&
+      handle &&
+      isSubject(handle.subject)
+    ) {
       _handle.data = handle.data
     }
   },
 
   unbind (el, binding) {
     const key = getKey(binding)
-    const handle = el._rxHandles && el._rxHandles[key]
+    const handle =
+      el._rxHandles && el._rxHandles[key]
     if (handle) {
       unsub(handle.subscription)
       el._rxHandles[key] = null

--- a/src/methods/createObservableMethod.js
+++ b/src/methods/createObservableMethod.js
@@ -7,17 +7,22 @@ import { Rx, hasRx, warn } from '../util'
  * @param {Boolean} [passContext] Append the call context at the end of emit data?
  * @return {Observable} Hot stream
  */
-export default function createObservableMethod (methodName, passContext) {
+export default function createObservableMethod (
+  methodName,
+  passContext
+) {
   if (!hasRx()) {
     return
   }
   const vm = this
 
-  if (!Rx.Observable.prototype.share) {
+  const share =
+    Rx.share || Rx.Observable.prototype.share
+  if (!share) {
     warn(
       `No 'share' operator. ` +
-      `$createObservableMethod returns a shared hot observable. ` +
-      `Try import 'rxjs/add/operator/share' for creating ${methodName}`,
+        `$createObservableMethod returns a shared hot observable. ` +
+        `Try import 'rxjs/add/operator/share' for creating ${methodName}`,
       vm
     )
     return
@@ -26,8 +31,8 @@ export default function createObservableMethod (methodName, passContext) {
   if (vm[methodName] !== undefined) {
     warn(
       'Potential bug: ' +
-      `Method ${methodName} already defined on vm and has been overwritten by $createObservableMethod.` +
-      String(vm[methodName]),
+        `Method ${methodName} already defined on vm and has been overwritten by $createObservableMethod.` +
+        String(vm[methodName]),
       vm
     )
   }
@@ -52,5 +57,11 @@ export default function createObservableMethod (methodName, passContext) {
   }
 
   // Must be a hot stream otherwise function context may overwrite over and over again
+
+  if (Rx.share) {
+    return Rx.Observable.create(creator).pipe(
+      share()
+    )
+  }
   return Rx.Observable.create(creator).share()
 }

--- a/test/v5.spec.js
+++ b/test/v5.spec.js
@@ -1,0 +1,533 @@
+/* eslint-env jest */
+
+'use strict'
+
+const Vue = require('vue/dist/vue.js')
+const VueRx = require('../dist/vue-rx.js')
+
+// library
+const Observable = require('rxjs-compat/Observable')
+  .Observable
+const Subject = require('rxjs-compat/Subject')
+  .Subject
+const Subscription = require('rxjs-compat/Subscription')
+  .Subscription
+require('rxjs-compat/add/observable/fromEvent')
+require('rxjs-compat/add/operator/share')
+
+// user
+require('rxjs-compat/add/operator/map')
+require('rxjs-compat/add/operator/startWith')
+require('rxjs-compat/add/operator/scan')
+require('rxjs-compat/add/operator/pluck')
+require('rxjs-compat/add/operator/merge')
+require('rxjs-compat/add/operator/filter')
+
+const miniRx = {
+  Observable,
+  Subscription,
+  Subject
+}
+
+Vue.config.productionTip = false
+Vue.use(VueRx, miniRx)
+
+const nextTick = Vue.nextTick
+
+function mock () {
+  let observer
+  const observable = Observable.create(
+    _observer => {
+      observer = _observer
+    }
+  )
+  return {
+    ob: observable,
+    next: val => observer.next(val)
+  }
+}
+
+function trigger (target, event) {
+  var e = document.createEvent('HTMLEvents')
+  e.initEvent(event, true, true)
+  target.dispatchEvent(e)
+}
+
+function click (target) {
+  trigger(target, 'click')
+}
+
+test('expose $observables', () => {
+  const { ob, next } = mock()
+
+  const vm = new Vue({
+    subscriptions: {
+      hello: ob.startWith(0)
+    }
+  })
+
+  const results = []
+  vm.$observables.hello.subscribe(val => {
+    results.push(val)
+  })
+
+  next(1)
+  next(2)
+  next(3)
+  expect(results).toEqual([0, 1, 2, 3])
+})
+
+test('bind subscriptions to render', done => {
+  const { ob, next } = mock()
+
+  const vm = new Vue({
+    subscriptions: {
+      hello: ob.startWith('foo')
+    },
+    render (h) {
+      return h('div', this.hello)
+    }
+  }).$mount()
+
+  expect(vm.$el.textContent).toBe('foo')
+
+  next('bar')
+  nextTick(() => {
+    expect(vm.$el.textContent).toBe('bar')
+    done()
+  })
+})
+
+test('subscriptions() has access to component state', () => {
+  const { ob } = mock()
+
+  const vm = new Vue({
+    data: {
+      foo: 'FOO'
+    },
+    props: ['bar'],
+    propsData: {
+      bar: 'BAR'
+    },
+    subscriptions () {
+      return {
+        hello: ob.startWith(this.foo + this.bar)
+      }
+    },
+    render (h) {
+      return h('div', this.hello)
+    }
+  }).$mount()
+
+  expect(vm.$el.textContent).toBe('FOOBAR')
+})
+
+/* I believe this is a breaking change of v6 :/
+test("subscriptions() can throw error properly", done => {
+  const { ob, next } = mock()
+
+  const vm = new Vue({
+    subscriptions() {
+      return {
+        num: ob.startWith(1).map(n => n.toFixed())
+      }
+    },
+    render(h) {
+      return h("div", this.num)
+    }
+  }).$mount()
+
+  nextTick(() => {
+    expect(() => {
+      next(null)
+    }).toThrow()
+    expect(vm.$el.textContent).toBe("1")
+    done()
+  })
+})
+*/
+
+test('v-stream directive (basic)', done => {
+  const vm = new Vue({
+    template: `
+      <div>
+        <span class="count">{{ count }}</span>
+        <button v-stream:click="click$">+</button>
+      </div>
+    `,
+    domStreams: ['click$'],
+    subscriptions () {
+      return {
+        count: this.click$
+          .map(() => 1)
+          .startWith(0)
+          .scan((total, change) => total + change)
+      }
+    }
+  }).$mount()
+
+  expect(
+    vm.$el.querySelector('span').textContent
+  ).toBe('0')
+  click(vm.$el.querySelector('button'))
+  nextTick(() => {
+    expect(
+      vm.$el.querySelector('span').textContent
+    ).toBe('1')
+    done()
+  })
+})
+
+test('v-stream directive (with .native modify)', done => {
+  const vm = new Vue({
+    template: `
+      <div>
+        <span class="count">{{ count }}</span>
+        <my-button id="btn-native" v-stream:click.native="clickNative$">+</my-button>
+        <my-button id="btn" v-stream:click="click$">-</my-button>
+      </div>
+    `,
+    components: {
+      myButton: {
+        template: '<button>MyButton</button>'
+      }
+    },
+    domStreams: ['clickNative$', 'click$'],
+    subscriptions () {
+      return {
+        count: this.clickNative$
+          .merge(this.click$)
+          .filter(
+            e =>
+              e.event.target &&
+              e.event.target.id === 'btn-native'
+          )
+          .map(() => 1)
+          .startWith(0)
+          .scan((total, change) => total + change)
+      }
+    }
+  }).$mount()
+
+  expect(
+    vm.$el.querySelector('span').textContent
+  ).toBe('0')
+  click(vm.$el.querySelector('#btn'))
+  click(vm.$el.querySelector('#btn'))
+  click(vm.$el.querySelector('#btn-native'))
+  nextTick(() => {
+    expect(
+      vm.$el.querySelector('span').textContent
+    ).toBe('1')
+    done()
+  })
+})
+
+test('v-stream directive (with .stop, .prevent modify)', done => {
+  const vm = new Vue({
+    template: `
+      <form>
+        <span>{{stoped}} {{prevented}}</span>
+        <button id="btn-stop" v-stream:click.stop="clickStop$">Stop</button>
+        <button id="btn-prevent" type="submit" v-stream:click.prevent="clickPrevent$">Submit</button>
+      </form>
+    `,
+    domStreams: ['clickStop$', 'clickPrevent$'],
+    subscriptions () {
+      return {
+        stoped: this.clickStop$.map(
+          x => x.event.cancelBubble
+        ),
+        prevented: this.clickPrevent$.map(
+          x => x.event.defaultPrevented
+        )
+      }
+    }
+  }).$mount()
+
+  click(vm.$el.querySelector('#btn-stop'))
+  click(vm.$el.querySelector('#btn-prevent'))
+  nextTick(() => {
+    expect(
+      vm.$el.querySelector('span').textContent
+    ).toBe('true true')
+    done()
+  })
+})
+
+test('v-stream directive (with data)', done => {
+  const vm = new Vue({
+    data: {
+      delta: -1
+    },
+    template: `
+      <div>
+        <span class="count">{{ count }}</span>
+        <button v-stream:click="{ subject: click$, data: delta }">+</button>
+      </div>
+    `,
+    domStreams: ['click$'],
+    subscriptions () {
+      return {
+        count: this.click$
+          .pluck('data')
+          .startWith(0)
+          .scan((total, change) => total + change)
+      }
+    }
+  }).$mount()
+
+  expect(
+    vm.$el.querySelector('span').textContent
+  ).toBe('0')
+  click(vm.$el.querySelector('button'))
+  nextTick(() => {
+    expect(
+      vm.$el.querySelector('span').textContent
+    ).toBe('-1')
+    vm.delta = 1
+    nextTick(() => {
+      click(vm.$el.querySelector('button'))
+      nextTick(() => {
+        expect(
+          vm.$el.querySelector('span').textContent
+        ).toBe('0')
+        done()
+      })
+    })
+  })
+})
+
+test('v-stream directive (multiple bindings on same node)', done => {
+  const vm = new Vue({
+    template: `
+      <div>
+        <span class="count">{{ count }}</span>
+        <button
+          v-stream:click="{ subject: plus$, data: 1 }"
+          v-stream:keyup="{ subject: plus$, data: -1 }">+</button>
+      </div>
+    `,
+    domStreams: ['plus$'],
+    subscriptions () {
+      return {
+        count: this.plus$
+          .pluck('data')
+          .startWith(0)
+          .scan((total, change) => total + change)
+      }
+    }
+  }).$mount()
+
+  expect(
+    vm.$el.querySelector('span').textContent
+  ).toBe('0')
+  click(vm.$el.querySelector('button'))
+  nextTick(() => {
+    expect(
+      vm.$el.querySelector('span').textContent
+    ).toBe('1')
+    trigger(
+      vm.$el.querySelector('button'),
+      'keyup'
+    )
+    nextTick(() => {
+      expect(
+        vm.$el.querySelector('span').textContent
+      ).toBe('0')
+      done()
+    })
+  })
+})
+
+test('$fromDOMEvent()', done => {
+  const vm = new Vue({
+    template: `
+      <div>
+        <span class="count">{{ count }}</span>
+        <button>+</button>
+      </div>
+    `,
+    subscriptions () {
+      const click$ = this.$fromDOMEvent(
+        'button',
+        'click'
+      )
+      return {
+        count: click$
+          .map(() => 1)
+          .startWith(0)
+          .scan((total, change) => total + change)
+      }
+    }
+  }).$mount()
+
+  document.body.appendChild(vm.$el)
+  expect(
+    vm.$el.querySelector('span').textContent
+  ).toBe('0')
+  click(vm.$el.querySelector('button'))
+  nextTick(() => {
+    expect(
+      vm.$el.querySelector('span').textContent
+    ).toBe('1')
+    done()
+  })
+})
+
+test('$watchAsObservable()', done => {
+  const vm = new Vue({
+    data: {
+      count: 0
+    }
+  })
+
+  const results = []
+  vm
+    .$watchAsObservable('count')
+    .subscribe(change => {
+      results.push(change)
+    })
+
+  vm.count++
+  nextTick(() => {
+    expect(results).toEqual([
+      { newValue: 1, oldValue: 0 }
+    ])
+    vm.count++
+    nextTick(() => {
+      expect(results).toEqual([
+        { newValue: 1, oldValue: 0 },
+        { newValue: 2, oldValue: 1 }
+      ])
+      done()
+    })
+  })
+})
+
+test('$subscribeTo()', () => {
+  const { ob, next } = mock()
+  const results = []
+  const vm = new Vue({
+    created () {
+      this.$subscribeTo(ob, count => {
+        results.push(count)
+      })
+    }
+  })
+
+  next(1)
+  expect(results).toEqual([1])
+
+  vm.$destroy()
+  next(2)
+  expect(results).toEqual([1]) // should not trigger anymore
+})
+
+test('$eventToObservable()', done => {
+  let calls = 0
+  const vm = new Vue({
+    created () {
+      this.$eventToObservable('ping').subscribe(
+        function (event) {
+          expect(event.name).toEqual('ping')
+          expect(event.msg).toEqual(
+            'ping message'
+          )
+          calls++
+        }
+      )
+    }
+  })
+  vm.$emit('ping', 'ping message')
+
+  nextTick(() => {
+    vm.$destroy()
+    // Should not emit
+    vm.$emit('pong', 'pong message')
+    expect(calls).toEqual(1)
+    done()
+  })
+})
+
+test('$eventToObservable() with lifecycle hooks', done => {
+  const vm = new Vue({
+    created () {
+      this.$eventToObservable(
+        'hook:beforeDestroy'
+      ).subscribe(() => {
+        done()
+      })
+    }
+  })
+  nextTick(() => {
+    vm.$destroy()
+  })
+})
+
+test('$createObservableMethod() with no context', done => {
+  const vm = new Vue({
+    created () {
+      this.$createObservableMethod(
+        'add'
+      ).subscribe(function (param) {
+        expect(param).toEqual('hola')
+        done()
+      })
+    }
+  })
+  nextTick(() => {
+    vm.add('hola')
+  })
+})
+
+test('$createObservableMethod() with muli params & context', done => {
+  const vm = new Vue({
+    created () {
+      this.$createObservableMethod(
+        'add',
+        true
+      ).subscribe(function (param) {
+        expect(param[0]).toEqual('hola')
+        expect(param[1]).toEqual('mundo')
+        expect(param[2]).toEqual(vm)
+        done()
+      })
+    }
+  })
+  nextTick(() => {
+    vm.add('hola', 'mundo')
+  })
+})
+
+test('observableMethods mixin', done => {
+  const vm = new Vue({
+    observableMethods: ['add'],
+    created () {
+      this.add$.subscribe(function (param) {
+        expect(param[0]).toEqual('Qué')
+        expect(param[1]).toEqual('tal')
+        done()
+      })
+    }
+  })
+  nextTick(() => {
+    vm.add('Qué', 'tal')
+  })
+})
+
+test('observableMethods mixin', done => {
+  const vm = new Vue({
+    observableMethods: { add: 'plus$' },
+    created () {
+      this.plus$.subscribe(function (param) {
+        expect(param[0]).toEqual('Qué')
+        expect(param[1]).toEqual('tal')
+        done()
+      })
+    }
+  })
+  nextTick(() => {
+    vm.add('Qué', 'tal')
+  })
+})


### PR DESCRIPTION
… if on Observable or require User to pass them into plugin config due to v6's breaking changes. Separated tests into v5 and v6.

For example:
v5: `Vue.use(VueRx, {Observable, Subject, Subscription})`
v6: `Vue.use(VueRx, {Observable, Subject, Subscription, fromEvent, share})`

The lib supports either approach.

P.S. - I noticed a lot of formatting changes. I used .editorconfig and linted, so not sure why so much move around…