### PR TITLE
RxJS V6 Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-rx",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4654,18 +4654,19 @@
       "dev": true
     },
     "rxjs": {
-      "version": "6.0.0-beta.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.0.0-beta.3.tgz",
-      "integrity": "sha512-Rkc4BDr75zsX4ozYOra9E0uAn8jDlnNvE7ISx/w6P7fkREmJH3Y0Zsz0FKRdo/AjWVzqytvjN1umHlTv/Ozayg==",
+      "version": "6.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.0.0-beta.4.tgz",
+      "integrity": "sha512-H+ghJ4H2mPrugoMfgbeky0yhmOrk4y0ykRyZpYvU2za0VbE2WTKgY/9pF7HJCogPFNIyI4GqI9Ujk3Xr4XxHbQ==",
       "dev": true,
       "requires": {
         "tslib": "1.9.0"
       }
     },
     "rxjs-compat": {
-      "version": "6.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/rxjs-compat/-/rxjs-compat-6.0.0-beta.1.tgz",
-      "integrity": "sha512-KfKSNhBStS1Vs/9ifOub430dTC4XUlPkPbbV7hexFX1+PmIF4RsW2LnHmSXiNfVPesdqRgiDvNZFkBMr4AqARA=="
+      "version": "6.0.0-beta.4",
+      "resolved": "https://registry.npmjs.org/rxjs-compat/-/rxjs-compat-6.0.0-beta.4.tgz",
+      "integrity": "sha512-Cx/vlb+KS+0ibFhKeupQWSmnEd4wot4cW7iBvGjtnVm7xe110VtqJaIjglaiojm3lmtjyLEiDSqkLGDiI+bWBA==",
+      "dev": true
     },
     "safe-buffer": {
       "version": "5.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4654,13 +4654,18 @@
       "dev": true
     },
     "rxjs": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.0.tgz",
-      "integrity": "sha512-vmvP5y/oJIJmXKHY36PIjVeI/46Sny6BMBa7/ou2zsNz1PiqU/Gtcz1GujnHz5Qlxncv+J9VlWmttnshqFj3Kg==",
+      "version": "6.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.0.0-beta.3.tgz",
+      "integrity": "sha512-Rkc4BDr75zsX4ozYOra9E0uAn8jDlnNvE7ISx/w6P7fkREmJH3Y0Zsz0FKRdo/AjWVzqytvjN1umHlTv/Ozayg==",
       "dev": true,
       "requires": {
-        "symbol-observable": "1.0.4"
+        "tslib": "1.9.0"
       }
+    },
+    "rxjs-compat": {
+      "version": "6.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/rxjs-compat/-/rxjs-compat-6.0.0-beta.1.tgz",
+      "integrity": "sha512-KfKSNhBStS1Vs/9ifOub430dTC4XUlPkPbbV7hexFX1+PmIF4RsW2LnHmSXiNfVPesdqRgiDvNZFkBMr4AqARA=="
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -4911,12 +4916,6 @@
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
       "dev": true
     },
-    "symbol-observable": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
-      "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=",
-      "dev": true
-    },
     "symbol-tree": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
@@ -5038,6 +5037,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
       "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+      "dev": true
+    },
+    "tslib": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
       "dev": true
     },
     "tunnel-agent": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       "integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
       "dev": true,
       "requires": {
-        "acorn": "4.0.13"
+        "acorn": "^4.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -39,7 +39,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "^3.0.4"
       }
     },
     "acorn-object-spread": {
@@ -48,7 +48,7 @@
       "integrity": "sha1-SOrQ9KjrFplaF6Dbn/xqyq2kumg=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "^3.1.0"
       }
     },
     "ajv": {
@@ -57,8 +57,8 @@
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
+        "co": "^4.6.0",
+        "json-stable-stringify": "^1.0.1"
       }
     },
     "ajv-keywords": {
@@ -73,9 +73,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -108,8 +108,8 @@
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
+        "micromatch": "^2.1.5",
+        "normalize-path": "^2.0.0"
       }
     },
     "append-transform": {
@@ -118,7 +118,7 @@
       "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
       "dev": true,
       "requires": {
-        "default-require-extensions": "1.0.0"
+        "default-require-extensions": "^1.0.0"
       }
     },
     "argparse": {
@@ -127,7 +127,7 @@
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "arr-diff": {
@@ -136,7 +136,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-flatten": {
@@ -157,7 +157,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -202,7 +202,7 @@
       "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "^4.14.0"
       }
     },
     "async-each": {
@@ -235,9 +235,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       }
     },
     "babel-core": {
@@ -246,25 +246,25 @@
       "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.0",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.0",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.0",
+        "debug": "^2.6.8",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.7",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.6"
       }
     },
     "babel-generator": {
@@ -273,14 +273,14 @@
       "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
       "dev": true,
       "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.4",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.6",
+        "trim-right": "^1.0.1"
       }
     },
     "babel-helpers": {
@@ -289,8 +289,8 @@
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
       }
     },
     "babel-jest": {
@@ -299,8 +299,8 @@
       "integrity": "sha512-O0W2qLoWu1QOoOGgxiR2JID4O6WSpxPiQanrkyi9SSlM0PJ60Ptzlck47lhtnr9YZO3zYOsxHwnyeWJ6AffoBQ==",
       "dev": true,
       "requires": {
-        "babel-plugin-istanbul": "4.1.5",
-        "babel-preset-jest": "21.2.0"
+        "babel-plugin-istanbul": "^4.0.0",
+        "babel-preset-jest": "^21.2.0"
       }
     },
     "babel-messages": {
@@ -309,7 +309,7 @@
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0"
+        "babel-runtime": "^6.22.0"
       }
     },
     "babel-plugin-istanbul": {
@@ -318,9 +318,9 @@
       "integrity": "sha1-Z2DN2Xf0EdPhdbsGTyvDJ9mbK24=",
       "dev": true,
       "requires": {
-        "find-up": "2.1.0",
-        "istanbul-lib-instrument": "1.8.0",
-        "test-exclude": "4.1.1"
+        "find-up": "^2.1.0",
+        "istanbul-lib-instrument": "^1.7.5",
+        "test-exclude": "^4.1.1"
       }
     },
     "babel-plugin-jest-hoist": {
@@ -341,8 +341,8 @@
       "integrity": "sha512-hm9cBnr2h3J7yXoTtAVV0zg+3vg0Q/gT2GYuzlreTU0EPkJRtlNgKJJ3tBKEn0+VjAi3JykV6xCJkuUYttEEfA==",
       "dev": true,
       "requires": {
-        "babel-plugin-jest-hoist": "21.2.0",
-        "babel-plugin-syntax-object-rest-spread": "6.13.0"
+        "babel-plugin-jest-hoist": "^21.2.0",
+        "babel-plugin-syntax-object-rest-spread": "^6.13.0"
       }
     },
     "babel-register": {
@@ -351,13 +351,13 @@
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.1",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
       }
     },
     "babel-runtime": {
@@ -366,8 +366,8 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.11.0"
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
       }
     },
     "babel-template": {
@@ -376,11 +376,11 @@
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.4"
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
       }
     },
     "babel-traverse": {
@@ -389,15 +389,15 @@
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.2",
-        "lodash": "4.17.4"
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
       }
     },
     "babel-types": {
@@ -406,10 +406,10 @@
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.4",
-        "to-fast-properties": "1.0.3"
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
       }
     },
     "babylon": {
@@ -431,7 +431,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "binary-extensions": {
@@ -446,7 +446,7 @@
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
       "dev": true,
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.x.x"
       }
     },
     "brace-expansion": {
@@ -455,7 +455,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -465,9 +465,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "browser-resolve": {
@@ -493,7 +493,7 @@
       "integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
       "dev": true,
       "requires": {
-        "node-int64": "0.4.0"
+        "node-int64": "^0.4.0"
       }
     },
     "buble": {
@@ -502,14 +502,14 @@
       "integrity": "sha512-Eb5vt1+IvXXPyYD1IIQIuaBwIuJOSWQ2kXzULlg5I83aLGF2qzcjRU2joYusnWFgAenvJ9xTOMvZvT0bb8BLbg==",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0",
-        "acorn-jsx": "3.0.1",
-        "acorn-object-spread": "1.0.0",
-        "chalk": "1.1.3",
-        "magic-string": "0.14.0",
-        "minimist": "1.2.0",
-        "os-homedir": "1.0.2",
-        "vlq": "0.2.3"
+        "acorn": "^3.3.0",
+        "acorn-jsx": "^3.0.1",
+        "acorn-object-spread": "^1.0.0",
+        "chalk": "^1.1.3",
+        "magic-string": "^0.14.0",
+        "minimist": "^1.2.0",
+        "os-homedir": "^1.0.1",
+        "vlq": "^0.2.2"
       }
     },
     "builtin-modules": {
@@ -524,7 +524,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsites": {
@@ -553,8 +553,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chalk": {
@@ -563,11 +563,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "chokidar": {
@@ -576,15 +576,15 @@
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.2",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
+        "anymatch": "^1.3.0",
+        "async-each": "^1.0.0",
+        "fsevents": "^1.0.0",
+        "glob-parent": "^2.0.0",
+        "inherits": "^2.0.1",
+        "is-binary-path": "^1.0.0",
+        "is-glob": "^2.0.0",
+        "path-is-absolute": "^1.0.0",
+        "readdirp": "^2.0.0"
       }
     },
     "ci-info": {
@@ -605,7 +605,7 @@
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "^1.0.1"
       }
     },
     "cli-width": {
@@ -621,8 +621,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -653,7 +653,7 @@
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -668,7 +668,7 @@
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "concat-map": {
@@ -683,9 +683,9 @@
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       }
     },
     "content-type-parser": {
@@ -718,9 +718,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "cryptiles": {
@@ -729,7 +729,7 @@
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
       "dev": true,
       "requires": {
-        "boom": "5.2.0"
+        "boom": "5.x.x"
       },
       "dependencies": {
         "boom": {
@@ -738,7 +738,7 @@
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "dev": true,
           "requires": {
-            "hoek": "4.2.0"
+            "hoek": "4.x.x"
           }
         }
       }
@@ -755,7 +755,7 @@
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
       "dev": true,
       "requires": {
-        "cssom": "0.3.2"
+        "cssom": "0.3.x"
       }
     },
     "d": {
@@ -764,7 +764,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.35"
+        "es5-ext": "^0.10.9"
       }
     },
     "dashdash": {
@@ -773,7 +773,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "debug": {
@@ -803,7 +803,7 @@
       "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
       "dev": true,
       "requires": {
-        "strip-bom": "2.0.0"
+        "strip-bom": "^2.0.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -812,7 +812,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         }
       }
@@ -823,13 +823,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "delayed-stream": {
@@ -844,7 +844,7 @@
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "diff": {
@@ -859,8 +859,8 @@
       "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
+        "esutils": "^2.0.2",
+        "isarray": "^1.0.0"
       }
     },
     "dom-serializer": {
@@ -869,8 +869,8 @@
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -893,7 +893,7 @@
       "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -902,8 +902,8 @@
       "integrity": "sha1-GVjMC0yUJuntNn+xyOhUiRsPo/8=",
       "dev": true,
       "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "ecc-jsbn": {
@@ -913,7 +913,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "entities": {
@@ -928,7 +928,7 @@
       "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
       "dev": true,
       "requires": {
-        "prr": "0.0.0"
+        "prr": "~0.0.0"
       }
     },
     "error-ex": {
@@ -937,7 +937,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "es5-ext": {
@@ -946,8 +946,8 @@
       "integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "es6-iterator": "~2.0.1",
+        "es6-symbol": "~3.1.1"
       }
     },
     "es6-iterator": {
@@ -956,9 +956,9 @@
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.35",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
       }
     },
     "es6-map": {
@@ -967,12 +967,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.35",
-        "es6-iterator": "2.0.3",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-set": {
@@ -981,11 +981,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.35",
-        "es6-iterator": "2.0.3",
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
         "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-symbol": {
@@ -994,8 +994,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.35"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "es6-weak-map": {
@@ -1004,10 +1004,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.35",
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escape-string-regexp": {
@@ -1022,11 +1022,11 @@
       "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
       "dev": true,
       "requires": {
-        "esprima": "3.1.3",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.5.7"
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.5.6"
       },
       "dependencies": {
         "esprima": {
@@ -1043,10 +1043,10 @@
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint": {
@@ -1055,41 +1055,41 @@
       "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "chalk": "1.1.3",
-        "concat-stream": "1.6.0",
-        "debug": "2.6.9",
-        "doctrine": "2.0.0",
-        "escope": "3.6.0",
-        "espree": "3.5.1",
-        "esquery": "1.0.0",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "glob": "7.1.2",
-        "globals": "9.18.0",
-        "ignore": "3.3.5",
-        "imurmurhash": "0.1.4",
-        "inquirer": "0.12.0",
-        "is-my-json-valid": "2.16.1",
-        "is-resolvable": "1.0.0",
-        "js-yaml": "3.10.0",
-        "json-stable-stringify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "1.2.1",
-        "progress": "1.1.8",
-        "require-uncached": "1.0.3",
-        "shelljs": "0.7.8",
-        "strip-bom": "3.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "3.8.3",
-        "text-table": "0.2.0",
-        "user-home": "2.0.0"
+        "babel-code-frame": "^6.16.0",
+        "chalk": "^1.1.3",
+        "concat-stream": "^1.5.2",
+        "debug": "^2.1.1",
+        "doctrine": "^2.0.0",
+        "escope": "^3.6.0",
+        "espree": "^3.4.0",
+        "esquery": "^1.0.0",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "glob": "^7.0.3",
+        "globals": "^9.14.0",
+        "ignore": "^3.2.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^0.12.0",
+        "is-my-json-valid": "^2.10.0",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.5.1",
+        "json-stable-stringify": "^1.0.0",
+        "levn": "^0.3.0",
+        "lodash": "^4.0.0",
+        "mkdirp": "^0.5.0",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.1",
+        "pluralize": "^1.2.1",
+        "progress": "^1.1.8",
+        "require-uncached": "^1.0.2",
+        "shelljs": "^0.7.5",
+        "strip-bom": "^3.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "^3.7.8",
+        "text-table": "~0.2.0",
+        "user-home": "^2.0.0"
       }
     },
     "eslint-plugin-html": {
@@ -1098,7 +1098,7 @@
       "integrity": "sha1-fImIOrDIX6XSi2ZqFKTpBqqQuJc=",
       "dev": true,
       "requires": {
-        "htmlparser2": "3.9.2"
+        "htmlparser2": "^3.8.2"
       }
     },
     "eslint-plugin-vue-libs": {
@@ -1107,7 +1107,7 @@
       "integrity": "sha512-GSmpfPqSX4d1Etnuh/w98qLw1voc1HYAF9nqROUTwKVz/d3mJEnuR9rJn8XDzBG1ddErBgO11kLI3TUVMNdJ+A==",
       "dev": true,
       "requires": {
-        "eslint-plugin-html": "2.0.3"
+        "eslint-plugin-html": "^2.0.0"
       }
     },
     "espree": {
@@ -1116,8 +1116,8 @@
       "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
       "dev": true,
       "requires": {
-        "acorn": "5.1.2",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^5.1.1",
+        "acorn-jsx": "^3.0.0"
       },
       "dependencies": {
         "acorn": {
@@ -1140,7 +1140,7 @@
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
@@ -1149,8 +1149,8 @@
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
+        "estraverse": "^4.1.0",
+        "object-assign": "^4.0.1"
       }
     },
     "estraverse": {
@@ -1177,8 +1177,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.35"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "exec-sh": {
@@ -1187,7 +1187,7 @@
       "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
       "dev": true,
       "requires": {
-        "merge": "1.2.0"
+        "merge": "^1.1.3"
       }
     },
     "execa": {
@@ -1196,13 +1196,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^5.0.1",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "exit-hook": {
@@ -1217,7 +1217,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -1226,7 +1226,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "^2.1.0"
       }
     },
     "expect": {
@@ -1235,12 +1235,12 @@
       "integrity": "sha512-orfQQqFRTX0jH7znRIGi8ZMR8kTNpXklTTz8+HGTpmTKZo3Occ6JNB5FXMb8cRuiiC/GyDqsr30zUa66ACYlYw==",
       "dev": true,
       "requires": {
-        "ansi-styles": "3.2.0",
-        "jest-diff": "21.2.1",
-        "jest-get-type": "21.2.0",
-        "jest-matcher-utils": "21.2.1",
-        "jest-message-util": "21.2.1",
-        "jest-regex-util": "21.2.0"
+        "ansi-styles": "^3.2.0",
+        "jest-diff": "^21.2.1",
+        "jest-get-type": "^21.2.0",
+        "jest-matcher-utils": "^21.2.1",
+        "jest-message-util": "^21.2.1",
+        "jest-regex-util": "^21.2.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -1249,7 +1249,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "^1.9.0"
           }
         }
       }
@@ -1266,7 +1266,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "extsprintf": {
@@ -1293,7 +1293,7 @@
       "integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
       "dev": true,
       "requires": {
-        "bser": "2.0.0"
+        "bser": "^2.0.0"
       }
     },
     "figures": {
@@ -1302,8 +1302,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
       }
     },
     "file-entry-cache": {
@@ -1312,8 +1312,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "filename-regex": {
@@ -1328,8 +1328,8 @@
       "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "minimatch": "3.0.4"
+        "glob": "^7.0.3",
+        "minimatch": "^3.0.3"
       }
     },
     "fill-range": {
@@ -1338,11 +1338,11 @@
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^1.1.3",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "find-up": {
@@ -1351,7 +1351,7 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "2.0.0"
+        "locate-path": "^2.0.0"
       }
     },
     "flat-cache": {
@@ -1360,10 +1360,10 @@
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       }
     },
     "for-in": {
@@ -1378,7 +1378,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "forever-agent": {
@@ -1393,9 +1393,9 @@
       "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
       "dev": true,
       "requires": {
-        "asynckit": "0.4.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.12"
       }
     },
     "fs.realpath": {
@@ -1411,8 +1411,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.7.0",
-        "node-pre-gyp": "0.6.36"
+        "nan": "^2.3.0",
+        "node-pre-gyp": "^0.6.36"
       },
       "dependencies": {
         "abbrev": {
@@ -1427,8 +1427,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
+            "co": "^4.6.0",
+            "json-stable-stringify": "^1.0.1"
           }
         },
         "ansi-regex": {
@@ -1448,8 +1448,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "asn1": {
@@ -1493,7 +1493,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "tweetnacl": "0.14.5"
+            "tweetnacl": "^0.14.3"
           }
         },
         "block-stream": {
@@ -1501,7 +1501,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "inherits": "2.0.3"
+            "inherits": "~2.0.0"
           }
         },
         "boom": {
@@ -1509,7 +1509,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "brace-expansion": {
@@ -1517,7 +1517,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "balanced-match": "0.4.2",
+            "balanced-match": "^0.4.1",
             "concat-map": "0.0.1"
           }
         },
@@ -1548,7 +1548,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "delayed-stream": "1.0.0"
+            "delayed-stream": "~1.0.0"
           }
         },
         "concat-map": {
@@ -1572,7 +1572,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "boom": "2.10.1"
+            "boom": "2.x.x"
           }
         },
         "dashdash": {
@@ -1581,7 +1581,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -1624,7 +1624,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "extend": {
@@ -1650,9 +1650,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "fs.realpath": {
@@ -1665,10 +1665,10 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
+            "graceful-fs": "^4.1.2",
+            "inherits": "~2.0.0",
+            "mkdirp": ">=0.5 0",
+            "rimraf": "2"
           }
         },
         "fstream-ignore": {
@@ -1677,9 +1677,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
+            "fstream": "^1.0.0",
+            "inherits": "2",
+            "minimatch": "^3.0.0"
           }
         },
         "gauge": {
@@ -1688,14 +1688,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "getpass": {
@@ -1704,7 +1704,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "1.0.0"
+            "assert-plus": "^1.0.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -1720,12 +1720,12 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "graceful-fs": {
@@ -1745,8 +1745,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
           }
         },
         "has-unicode": {
@@ -1761,10 +1761,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
+            "boom": "2.x.x",
+            "cryptiles": "2.x.x",
+            "hoek": "2.x.x",
+            "sntp": "1.x.x"
           }
         },
         "hoek": {
@@ -1778,9 +1778,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
+            "assert-plus": "^0.2.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
           }
         },
         "inflight": {
@@ -1788,8 +1788,8 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -1808,7 +1808,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-typedarray": {
@@ -1834,7 +1834,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsbn": "0.1.1"
+            "jsbn": "~0.1.0"
           }
         },
         "jsbn": {
@@ -1855,7 +1855,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "jsonify": "0.0.0"
+            "jsonify": "~0.0.0"
           }
         },
         "json-stringify-safe": {
@@ -1900,7 +1900,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mime-db": "1.27.0"
+            "mime-db": "~1.27.0"
           }
         },
         "minimatch": {
@@ -1908,7 +1908,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.7"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -1936,15 +1936,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
+            "mkdirp": "^0.5.1",
+            "nopt": "^4.0.1",
+            "npmlog": "^4.0.2",
+            "rc": "^1.1.7",
+            "request": "^2.81.0",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^2.2.1",
+            "tar-pack": "^3.4.0"
           }
         },
         "nopt": {
@@ -1953,8 +1953,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "npmlog": {
@@ -1963,10 +1963,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -1991,7 +1991,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "os-homedir": {
@@ -2012,8 +2012,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {
@@ -2050,10 +2050,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "~0.4.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -2069,13 +2069,13 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
+            "buffer-shims": "~1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~1.0.0",
+            "util-deprecate": "~1.0.1"
           }
         },
         "request": {
@@ -2084,28 +2084,28 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~4.2.1",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "performance-now": "^0.2.0",
+            "qs": "~6.4.0",
+            "safe-buffer": "^5.0.1",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.0.0"
           }
         },
         "rimraf": {
@@ -2113,7 +2113,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         },
         "safe-buffer": {
@@ -2145,7 +2145,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "hoek": "2.16.3"
+            "hoek": "2.x.x"
           }
         },
         "sshpk": {
@@ -2154,15 +2154,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jodid25519": "^1.0.0",
+            "jsbn": "~0.1.0",
+            "tweetnacl": "~0.14.0"
           },
           "dependencies": {
             "assert-plus": {
@@ -2178,9 +2178,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
@@ -2188,7 +2188,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "5.0.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "stringstream": {
@@ -2202,7 +2202,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-json-comments": {
@@ -2216,9 +2216,9 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
+            "block-stream": "*",
+            "fstream": "^1.0.2",
+            "inherits": "2"
           }
         },
         "tar-pack": {
@@ -2227,14 +2227,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
+            "debug": "^2.2.0",
+            "fstream": "^1.0.10",
+            "fstream-ignore": "^1.0.5",
+            "once": "^1.3.3",
+            "readable-stream": "^2.1.4",
+            "rimraf": "^2.5.1",
+            "tar": "^2.2.1",
+            "uid-number": "^0.0.6"
           }
         },
         "tough-cookie": {
@@ -2243,7 +2243,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "punycode": "1.4.1"
+            "punycode": "^1.4.1"
           }
         },
         "tunnel-agent": {
@@ -2252,7 +2252,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "5.0.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
@@ -2293,7 +2293,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2"
           }
         },
         "wrappy": {
@@ -2315,7 +2315,7 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.0"
       }
     },
     "get-caller-file": {
@@ -2336,7 +2336,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -2345,12 +2345,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "glob-base": {
@@ -2359,8 +2359,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "glob-parent": {
@@ -2369,7 +2369,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "globals": {
@@ -2384,12 +2384,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "graceful-fs": {
@@ -2410,10 +2410,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       },
       "dependencies": {
         "async": {
@@ -2428,7 +2428,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -2445,8 +2445,8 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "5.2.3",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       },
       "dependencies": {
         "ajv": {
@@ -2455,10 +2455,10 @@
           "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
           "dev": true,
           "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.0.0",
-            "json-schema-traverse": "0.3.1",
-            "json-stable-stringify": "1.0.1"
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "json-schema-traverse": "^0.3.0",
+            "json-stable-stringify": "^1.0.1"
           }
         }
       }
@@ -2469,7 +2469,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -2484,10 +2484,10 @@
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "dev": true,
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.0",
-        "sntp": "2.0.2"
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
       }
     },
     "hoek": {
@@ -2502,8 +2502,8 @@
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
       }
     },
     "hosted-git-info": {
@@ -2518,7 +2518,7 @@
       "integrity": "sha1-eb96eF6klf5mFl5zQVPzY/9UN9o=",
       "dev": true,
       "requires": {
-        "whatwg-encoding": "1.0.1"
+        "whatwg-encoding": "^1.0.1"
       }
     },
     "htmlparser2": {
@@ -2527,12 +2527,12 @@
       "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.4.1",
-        "domutils": "1.6.2",
-        "entities": "1.1.1",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3"
+        "domelementtype": "^1.3.0",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.2"
       }
     },
     "http-signature": {
@@ -2541,9 +2541,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -2570,8 +2570,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -2586,19 +2586,19 @@
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "ansi-regex": "2.1.1",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-width": "2.2.0",
-        "figures": "1.7.0",
-        "lodash": "4.17.4",
-        "readline2": "1.0.1",
-        "run-async": "0.1.0",
-        "rx-lite": "3.1.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "through": "2.3.8"
+        "ansi-escapes": "^1.1.0",
+        "ansi-regex": "^2.0.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^2.0.0",
+        "figures": "^1.3.5",
+        "lodash": "^4.3.0",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^3.1.2",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
       }
     },
     "interpret": {
@@ -2613,7 +2613,7 @@
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
       "dev": true,
       "requires": {
-        "loose-envify": "1.3.1"
+        "loose-envify": "^1.0.0"
       }
     },
     "invert-kv": {
@@ -2634,7 +2634,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.10.0"
+        "binary-extensions": "^1.0.0"
       }
     },
     "is-buffer": {
@@ -2649,7 +2649,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-ci": {
@@ -2658,7 +2658,7 @@
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
       "dev": true,
       "requires": {
-        "ci-info": "1.1.1"
+        "ci-info": "^1.0.0"
       }
     },
     "is-dotfile": {
@@ -2673,7 +2673,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -2694,7 +2694,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -2703,7 +2703,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-glob": {
@@ -2712,7 +2712,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-my-json-valid": {
@@ -2721,10 +2721,10 @@
       "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
       "dev": true,
       "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "is-number": {
@@ -2733,7 +2733,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-path-cwd": {
@@ -2748,7 +2748,7 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -2757,7 +2757,7 @@
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-posix-bracket": {
@@ -2784,7 +2784,7 @@
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
       "dev": true,
       "requires": {
-        "tryit": "1.0.3"
+        "tryit": "^1.0.1"
       }
     },
     "is-stream": {
@@ -2838,17 +2838,17 @@
       "integrity": "sha1-JbxXAffGgMD//5E95G42GaOm5oA=",
       "dev": true,
       "requires": {
-        "async": "2.5.0",
-        "fileset": "2.0.3",
-        "istanbul-lib-coverage": "1.1.1",
-        "istanbul-lib-hook": "1.0.7",
-        "istanbul-lib-instrument": "1.8.0",
-        "istanbul-lib-report": "1.1.1",
-        "istanbul-lib-source-maps": "1.2.1",
-        "istanbul-reports": "1.1.2",
-        "js-yaml": "3.10.0",
-        "mkdirp": "0.5.1",
-        "once": "1.4.0"
+        "async": "^2.1.4",
+        "fileset": "^2.0.2",
+        "istanbul-lib-coverage": "^1.1.1",
+        "istanbul-lib-hook": "^1.0.7",
+        "istanbul-lib-instrument": "^1.8.0",
+        "istanbul-lib-report": "^1.1.1",
+        "istanbul-lib-source-maps": "^1.2.1",
+        "istanbul-reports": "^1.1.2",
+        "js-yaml": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "once": "^1.4.0"
       }
     },
     "istanbul-lib-coverage": {
@@ -2863,7 +2863,7 @@
       "integrity": "sha512-3U2HB9y1ZV9UmFlE12Fx+nPtFqIymzrqCksrXujm3NVbAZIJg/RfYgO1XiIa0mbmxTjWpVEVlkIZJ25xVIAfkQ==",
       "dev": true,
       "requires": {
-        "append-transform": "0.4.0"
+        "append-transform": "^0.4.0"
       }
     },
     "istanbul-lib-instrument": {
@@ -2872,13 +2872,13 @@
       "integrity": "sha1-ZvbJQhzJ7EcE928tsIS6kHiitTI=",
       "dev": true,
       "requires": {
-        "babel-generator": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "istanbul-lib-coverage": "1.1.1",
-        "semver": "5.4.1"
+        "babel-generator": "^6.18.0",
+        "babel-template": "^6.16.0",
+        "babel-traverse": "^6.18.0",
+        "babel-types": "^6.18.0",
+        "babylon": "^6.18.0",
+        "istanbul-lib-coverage": "^1.1.1",
+        "semver": "^5.3.0"
       }
     },
     "istanbul-lib-report": {
@@ -2887,10 +2887,10 @@
       "integrity": "sha512-tvF+YmCmH4thnez6JFX06ujIA19WPa9YUiwjc1uALF2cv5dmE3It8b5I8Ob7FHJ70H9Y5yF+TDkVa/mcADuw1Q==",
       "dev": true,
       "requires": {
-        "istanbul-lib-coverage": "1.1.1",
-        "mkdirp": "0.5.1",
-        "path-parse": "1.0.5",
-        "supports-color": "3.2.3"
+        "istanbul-lib-coverage": "^1.1.1",
+        "mkdirp": "^0.5.1",
+        "path-parse": "^1.0.5",
+        "supports-color": "^3.1.2"
       },
       "dependencies": {
         "has-flag": {
@@ -2905,7 +2905,7 @@
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true,
           "requires": {
-            "has-flag": "1.0.0"
+            "has-flag": "^1.0.0"
           }
         }
       }
@@ -2916,11 +2916,11 @@
       "integrity": "sha512-mukVvSXCn9JQvdJl8wP/iPhqig0MRtuWuD4ZNKo6vB2Ik//AmhAKe3QnPN02dmkRe3lTudFk3rzoHhwU4hb94w==",
       "dev": true,
       "requires": {
-        "debug": "2.6.9",
-        "istanbul-lib-coverage": "1.1.1",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.6.2",
-        "source-map": "0.5.7"
+        "debug": "^2.6.3",
+        "istanbul-lib-coverage": "^1.1.1",
+        "mkdirp": "^0.5.1",
+        "rimraf": "^2.6.1",
+        "source-map": "^0.5.3"
       }
     },
     "istanbul-reports": {
@@ -2929,7 +2929,7 @@
       "integrity": "sha1-D7Lj9qqZIr085F0F2KtNXo4HvU8=",
       "dev": true,
       "requires": {
-        "handlebars": "4.0.11"
+        "handlebars": "^4.0.3"
       }
     },
     "jest": {
@@ -2938,7 +2938,7 @@
       "integrity": "sha512-mXN0ppPvWYoIcC+R+ctKxAJ28xkt/Z5Js875padm4GbgUn6baeR5N4Ng6LjatIRpUQDZVJABT7Y4gucFjPryfw==",
       "dev": true,
       "requires": {
-        "jest-cli": "21.2.1"
+        "jest-cli": "^21.2.1"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -2959,7 +2959,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -2968,9 +2968,9 @@
           "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "jest-cli": {
@@ -2979,35 +2979,35 @@
           "integrity": "sha512-T1BzrbFxDIW/LLYQqVfo94y/hhaj1NzVQkZgBumAC+sxbjMROI7VkihOdxNR758iYbQykL2ZOWUBurFgkQrzdg==",
           "dev": true,
           "requires": {
-            "ansi-escapes": "3.0.0",
-            "chalk": "2.2.0",
-            "glob": "7.1.2",
-            "graceful-fs": "4.1.11",
-            "is-ci": "1.0.10",
-            "istanbul-api": "1.1.14",
-            "istanbul-lib-coverage": "1.1.1",
-            "istanbul-lib-instrument": "1.8.0",
-            "istanbul-lib-source-maps": "1.2.1",
-            "jest-changed-files": "21.2.0",
-            "jest-config": "21.2.1",
-            "jest-environment-jsdom": "21.2.1",
-            "jest-haste-map": "21.2.0",
-            "jest-message-util": "21.2.1",
-            "jest-regex-util": "21.2.0",
-            "jest-resolve-dependencies": "21.2.0",
-            "jest-runner": "21.2.1",
-            "jest-runtime": "21.2.1",
-            "jest-snapshot": "21.2.1",
-            "jest-util": "21.2.1",
-            "micromatch": "2.3.11",
-            "node-notifier": "5.1.2",
-            "pify": "3.0.0",
-            "slash": "1.0.0",
-            "string-length": "2.0.0",
-            "strip-ansi": "4.0.0",
-            "which": "1.3.0",
-            "worker-farm": "1.5.0",
-            "yargs": "9.0.1"
+            "ansi-escapes": "^3.0.0",
+            "chalk": "^2.0.1",
+            "glob": "^7.1.2",
+            "graceful-fs": "^4.1.11",
+            "is-ci": "^1.0.10",
+            "istanbul-api": "^1.1.1",
+            "istanbul-lib-coverage": "^1.0.1",
+            "istanbul-lib-instrument": "^1.4.2",
+            "istanbul-lib-source-maps": "^1.1.0",
+            "jest-changed-files": "^21.2.0",
+            "jest-config": "^21.2.1",
+            "jest-environment-jsdom": "^21.2.1",
+            "jest-haste-map": "^21.2.0",
+            "jest-message-util": "^21.2.1",
+            "jest-regex-util": "^21.2.0",
+            "jest-resolve-dependencies": "^21.2.0",
+            "jest-runner": "^21.2.1",
+            "jest-runtime": "^21.2.1",
+            "jest-snapshot": "^21.2.1",
+            "jest-util": "^21.2.1",
+            "micromatch": "^2.3.11",
+            "node-notifier": "^5.0.2",
+            "pify": "^3.0.0",
+            "slash": "^1.0.0",
+            "string-length": "^2.0.0",
+            "strip-ansi": "^4.0.0",
+            "which": "^1.2.12",
+            "worker-farm": "^1.3.1",
+            "yargs": "^9.0.0"
           }
         },
         "pify": {
@@ -3022,7 +3022,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "supports-color": {
@@ -3031,7 +3031,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -3042,7 +3042,7 @@
       "integrity": "sha512-+lCNP1IZLwN1NOIvBcV5zEL6GENK6TXrDj4UxWIeLvIsIDa+gf6J7hkqsW2qVVt/wvH65rVvcPwqXdps5eclTQ==",
       "dev": true,
       "requires": {
-        "throat": "4.1.0"
+        "throat": "^4.0.0"
       }
     },
     "jest-config": {
@@ -3051,17 +3051,17 @@
       "integrity": "sha512-fJru5HtlD/5l2o25eY9xT0doK3t2dlglrqoGpbktduyoI0T5CwuB++2YfoNZCrgZipTwPuAGonYv0q7+8yDc/A==",
       "dev": true,
       "requires": {
-        "chalk": "2.2.0",
-        "glob": "7.1.2",
-        "jest-environment-jsdom": "21.2.1",
-        "jest-environment-node": "21.2.1",
-        "jest-get-type": "21.2.0",
-        "jest-jasmine2": "21.2.1",
-        "jest-regex-util": "21.2.0",
-        "jest-resolve": "21.2.0",
-        "jest-util": "21.2.1",
-        "jest-validate": "21.2.1",
-        "pretty-format": "21.2.1"
+        "chalk": "^2.0.1",
+        "glob": "^7.1.1",
+        "jest-environment-jsdom": "^21.2.1",
+        "jest-environment-node": "^21.2.1",
+        "jest-get-type": "^21.2.0",
+        "jest-jasmine2": "^21.2.1",
+        "jest-regex-util": "^21.2.0",
+        "jest-resolve": "^21.2.0",
+        "jest-util": "^21.2.1",
+        "jest-validate": "^21.2.1",
+        "pretty-format": "^21.2.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3070,7 +3070,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -3079,9 +3079,9 @@
           "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "supports-color": {
@@ -3090,7 +3090,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -3101,10 +3101,10 @@
       "integrity": "sha512-E5fu6r7PvvPr5qAWE1RaUwIh/k6Zx/3OOkZ4rk5dBJkEWRrUuSgbMt2EO8IUTPTd6DOqU3LW6uTIwX5FRvXoFA==",
       "dev": true,
       "requires": {
-        "chalk": "2.2.0",
-        "diff": "3.4.0",
-        "jest-get-type": "21.2.0",
-        "pretty-format": "21.2.1"
+        "chalk": "^2.0.1",
+        "diff": "^3.2.0",
+        "jest-get-type": "^21.2.0",
+        "pretty-format": "^21.2.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3113,7 +3113,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -3122,9 +3122,9 @@
           "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "supports-color": {
@@ -3133,7 +3133,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -3150,9 +3150,9 @@
       "integrity": "sha512-mecaeNh0eWmzNrUNMWARysc0E9R96UPBamNiOCYL28k7mksb1d0q6DD38WKP7ABffjnXyUWJPVaWRgUOivwXwg==",
       "dev": true,
       "requires": {
-        "jest-mock": "21.2.0",
-        "jest-util": "21.2.1",
-        "jsdom": "9.12.0"
+        "jest-mock": "^21.2.0",
+        "jest-util": "^21.2.1",
+        "jsdom": "^9.12.0"
       }
     },
     "jest-environment-node": {
@@ -3161,8 +3161,8 @@
       "integrity": "sha512-R211867wx9mVBVHzrjGRGTy5cd05K7eqzQl/WyZixR/VkJ4FayS8qkKXZyYnwZi6Rxo6WEV81cDbiUx/GfuLNw==",
       "dev": true,
       "requires": {
-        "jest-mock": "21.2.0",
-        "jest-util": "21.2.1"
+        "jest-mock": "^21.2.0",
+        "jest-util": "^21.2.1"
       }
     },
     "jest-get-type": {
@@ -3177,12 +3177,12 @@
       "integrity": "sha512-5LhsY/loPH7wwOFRMs+PT4aIAORJ2qwgbpMFlbWbxfN0bk3ZCwxJ530vrbSiTstMkYLao6JwBkLhCJ5XbY7ZHw==",
       "dev": true,
       "requires": {
-        "fb-watchman": "2.0.0",
-        "graceful-fs": "4.1.11",
-        "jest-docblock": "21.2.0",
-        "micromatch": "2.3.11",
-        "sane": "2.2.0",
-        "worker-farm": "1.5.0"
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.1.11",
+        "jest-docblock": "^21.2.0",
+        "micromatch": "^2.3.11",
+        "sane": "^2.0.0",
+        "worker-farm": "^1.3.1"
       }
     },
     "jest-jasmine2": {
@@ -3191,14 +3191,14 @@
       "integrity": "sha512-lw8FXXIEekD+jYNlStfgNsUHpfMWhWWCgHV7n0B7mA/vendH7vBFs8xybjQsDzJSduptBZJHqQX9SMssya9+3A==",
       "dev": true,
       "requires": {
-        "chalk": "2.2.0",
-        "expect": "21.2.1",
-        "graceful-fs": "4.1.11",
-        "jest-diff": "21.2.1",
-        "jest-matcher-utils": "21.2.1",
-        "jest-message-util": "21.2.1",
-        "jest-snapshot": "21.2.1",
-        "p-cancelable": "0.3.0"
+        "chalk": "^2.0.1",
+        "expect": "^21.2.1",
+        "graceful-fs": "^4.1.11",
+        "jest-diff": "^21.2.1",
+        "jest-matcher-utils": "^21.2.1",
+        "jest-message-util": "^21.2.1",
+        "jest-snapshot": "^21.2.1",
+        "p-cancelable": "^0.3.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3207,7 +3207,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -3216,9 +3216,9 @@
           "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "supports-color": {
@@ -3227,7 +3227,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -3238,9 +3238,9 @@
       "integrity": "sha512-kn56My+sekD43dwQPrXBl9Zn9tAqwoy25xxe7/iY4u+mG8P3ALj5IK7MLHZ4Mi3xW7uWVCjGY8cm4PqgbsqMCg==",
       "dev": true,
       "requires": {
-        "chalk": "2.2.0",
-        "jest-get-type": "21.2.0",
-        "pretty-format": "21.2.1"
+        "chalk": "^2.0.1",
+        "jest-get-type": "^21.2.0",
+        "pretty-format": "^21.2.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3249,7 +3249,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -3258,9 +3258,9 @@
           "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "supports-color": {
@@ -3269,7 +3269,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -3280,9 +3280,9 @@
       "integrity": "sha512-EbC1X2n0t9IdeMECJn2BOg7buOGivCvVNjqKMXTzQOu7uIfLml+keUfCALDh8o4rbtndIeyGU8/BKfoTr/LVDQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.2.0",
-        "micromatch": "2.3.11",
-        "slash": "1.0.0"
+        "chalk": "^2.0.1",
+        "micromatch": "^2.3.11",
+        "slash": "^1.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3291,7 +3291,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -3300,9 +3300,9 @@
           "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "supports-color": {
@@ -3311,7 +3311,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -3334,9 +3334,9 @@
       "integrity": "sha512-vefQ/Lr+VdNvHUZFQXWtOqHX3HEdOc2MtSahBO89qXywEbUxGPB9ZLP9+BHinkxb60UT2Q/tTDOS6rYc6Mwigw==",
       "dev": true,
       "requires": {
-        "browser-resolve": "1.11.2",
-        "chalk": "2.2.0",
-        "is-builtin-module": "1.0.0"
+        "browser-resolve": "^1.11.2",
+        "chalk": "^2.0.1",
+        "is-builtin-module": "^1.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3345,7 +3345,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -3354,9 +3354,9 @@
           "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "supports-color": {
@@ -3365,7 +3365,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -3376,7 +3376,7 @@
       "integrity": "sha512-ok8ybRFU5ScaAcfufIQrCbdNJSRZ85mkxJ1EhUp8Bhav1W1/jv/rl1Q6QoVQHObNxmKnbHVKrfLZbCbOsXQ+bQ==",
       "dev": true,
       "requires": {
-        "jest-regex-util": "21.2.0"
+        "jest-regex-util": "^21.2.0"
       }
     },
     "jest-runner": {
@@ -3385,16 +3385,16 @@
       "integrity": "sha512-Anb72BOQlHqF/zETqZ2K20dbYsnqW/nZO7jV8BYENl+3c44JhMrA8zd1lt52+N7ErnsQMd2HHKiVwN9GYSXmrg==",
       "dev": true,
       "requires": {
-        "jest-config": "21.2.1",
-        "jest-docblock": "21.2.0",
-        "jest-haste-map": "21.2.0",
-        "jest-jasmine2": "21.2.1",
-        "jest-message-util": "21.2.1",
-        "jest-runtime": "21.2.1",
-        "jest-util": "21.2.1",
-        "pify": "3.0.0",
-        "throat": "4.1.0",
-        "worker-farm": "1.5.0"
+        "jest-config": "^21.2.1",
+        "jest-docblock": "^21.2.0",
+        "jest-haste-map": "^21.2.0",
+        "jest-jasmine2": "^21.2.1",
+        "jest-message-util": "^21.2.1",
+        "jest-runtime": "^21.2.1",
+        "jest-util": "^21.2.1",
+        "pify": "^3.0.0",
+        "throat": "^4.0.0",
+        "worker-farm": "^1.3.1"
       },
       "dependencies": {
         "pify": {
@@ -3411,23 +3411,23 @@
       "integrity": "sha512-6omlpA3+NSE+rHwD0PQjNEjZeb2z+oRmuehMfM1tWQVum+E0WV3pFt26Am0DUfQkkPyTABvxITRjCUclYgSOsA==",
       "dev": true,
       "requires": {
-        "babel-core": "6.26.0",
-        "babel-jest": "21.2.0",
-        "babel-plugin-istanbul": "4.1.5",
-        "chalk": "2.2.0",
-        "convert-source-map": "1.5.0",
-        "graceful-fs": "4.1.11",
-        "jest-config": "21.2.1",
-        "jest-haste-map": "21.2.0",
-        "jest-regex-util": "21.2.0",
-        "jest-resolve": "21.2.0",
-        "jest-util": "21.2.1",
-        "json-stable-stringify": "1.0.1",
-        "micromatch": "2.3.11",
-        "slash": "1.0.0",
+        "babel-core": "^6.0.0",
+        "babel-jest": "^21.2.0",
+        "babel-plugin-istanbul": "^4.0.0",
+        "chalk": "^2.0.1",
+        "convert-source-map": "^1.4.0",
+        "graceful-fs": "^4.1.11",
+        "jest-config": "^21.2.1",
+        "jest-haste-map": "^21.2.0",
+        "jest-regex-util": "^21.2.0",
+        "jest-resolve": "^21.2.0",
+        "jest-util": "^21.2.1",
+        "json-stable-stringify": "^1.0.1",
+        "micromatch": "^2.3.11",
+        "slash": "^1.0.0",
         "strip-bom": "3.0.0",
-        "write-file-atomic": "2.3.0",
-        "yargs": "9.0.1"
+        "write-file-atomic": "^2.1.0",
+        "yargs": "^9.0.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3436,7 +3436,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -3445,9 +3445,9 @@
           "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "supports-color": {
@@ -3456,7 +3456,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -3467,12 +3467,12 @@
       "integrity": "sha512-bpaeBnDpdqaRTzN8tWg0DqOTo2DvD3StOemxn67CUd1p1Po+BUpvePAp44jdJ7Pxcjfg+42o4NHw1SxdCA2rvg==",
       "dev": true,
       "requires": {
-        "chalk": "2.2.0",
-        "jest-diff": "21.2.1",
-        "jest-matcher-utils": "21.2.1",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "pretty-format": "21.2.1"
+        "chalk": "^2.0.1",
+        "jest-diff": "^21.2.1",
+        "jest-matcher-utils": "^21.2.1",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^21.2.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3481,7 +3481,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -3490,9 +3490,9 @@
           "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "supports-color": {
@@ -3501,7 +3501,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -3512,13 +3512,13 @@
       "integrity": "sha512-r20W91rmHY3fnCoO7aOAlyfC51x2yeV3xF+prGsJAUsYhKeV670ZB8NO88Lwm7ASu8SdH0S+U+eFf498kjhA4g==",
       "dev": true,
       "requires": {
-        "callsites": "2.0.0",
-        "chalk": "2.2.0",
-        "graceful-fs": "4.1.11",
-        "jest-message-util": "21.2.1",
-        "jest-mock": "21.2.0",
-        "jest-validate": "21.2.1",
-        "mkdirp": "0.5.1"
+        "callsites": "^2.0.0",
+        "chalk": "^2.0.1",
+        "graceful-fs": "^4.1.11",
+        "jest-message-util": "^21.2.1",
+        "jest-mock": "^21.2.0",
+        "jest-validate": "^21.2.1",
+        "mkdirp": "^0.5.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3527,7 +3527,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "^1.9.0"
           }
         },
         "callsites": {
@@ -3542,9 +3542,9 @@
           "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "supports-color": {
@@ -3553,7 +3553,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -3564,10 +3564,10 @@
       "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
       "dev": true,
       "requires": {
-        "chalk": "2.2.0",
-        "jest-get-type": "21.2.0",
-        "leven": "2.1.0",
-        "pretty-format": "21.2.1"
+        "chalk": "^2.0.1",
+        "jest-get-type": "^21.2.0",
+        "leven": "^2.1.0",
+        "pretty-format": "^21.2.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3576,7 +3576,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -3585,9 +3585,9 @@
           "integrity": "sha512-0BMM/2hG3ZaoPfR6F+h/oWpZtsh3b/s62TjSM6MGCJWEbJDN1acqCXvyhhZsDSVFklpebUoQ5O1kKC7lOzrn9g==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "ansi-styles": "^3.1.0",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^4.0.0"
           }
         },
         "supports-color": {
@@ -3596,7 +3596,7 @@
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "^2.0.0"
           }
         }
       }
@@ -3613,8 +3613,8 @@
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.9",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       }
     },
     "jsbn": {
@@ -3630,25 +3630,25 @@
       "integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
       "dev": true,
       "requires": {
-        "abab": "1.0.4",
-        "acorn": "4.0.13",
-        "acorn-globals": "3.1.0",
-        "array-equal": "1.0.0",
-        "content-type-parser": "1.0.1",
-        "cssom": "0.3.2",
-        "cssstyle": "0.2.37",
-        "escodegen": "1.9.0",
-        "html-encoding-sniffer": "1.0.1",
-        "nwmatcher": "1.4.3",
-        "parse5": "1.5.1",
-        "request": "2.83.0",
-        "sax": "1.2.4",
-        "symbol-tree": "3.2.2",
-        "tough-cookie": "2.3.3",
-        "webidl-conversions": "4.0.2",
-        "whatwg-encoding": "1.0.1",
-        "whatwg-url": "4.8.0",
-        "xml-name-validator": "2.0.1"
+        "abab": "^1.0.3",
+        "acorn": "^4.0.4",
+        "acorn-globals": "^3.1.0",
+        "array-equal": "^1.0.0",
+        "content-type-parser": "^1.0.1",
+        "cssom": ">= 0.3.2 < 0.4.0",
+        "cssstyle": ">= 0.2.37 < 0.3.0",
+        "escodegen": "^1.6.1",
+        "html-encoding-sniffer": "^1.0.1",
+        "nwmatcher": ">= 1.3.9 < 2.0.0",
+        "parse5": "^1.5.1",
+        "request": "^2.79.0",
+        "sax": "^1.2.1",
+        "symbol-tree": "^3.2.1",
+        "tough-cookie": "^2.3.2",
+        "webidl-conversions": "^4.0.0",
+        "whatwg-encoding": "^1.0.1",
+        "whatwg-url": "^4.3.0",
+        "xml-name-validator": "^2.0.1"
       },
       "dependencies": {
         "acorn": {
@@ -3683,7 +3683,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -3728,7 +3728,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.5"
+        "is-buffer": "^1.1.5"
       }
     },
     "lazy-cache": {
@@ -3744,7 +3744,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "leven": {
@@ -3759,8 +3759,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "load-json-file": {
@@ -3769,11 +3769,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       },
       "dependencies": {
         "strip-bom": {
@@ -3782,7 +3782,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         }
       }
@@ -3793,8 +3793,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
       }
     },
     "lodash": {
@@ -3815,7 +3815,7 @@
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
       "dev": true,
       "requires": {
-        "js-tokens": "3.0.2"
+        "js-tokens": "^3.0.0"
       }
     },
     "lru-cache": {
@@ -3824,8 +3824,8 @@
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "dev": true,
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
       }
     },
     "magic-string": {
@@ -3834,7 +3834,7 @@
       "integrity": "sha1-VyJK7xcByu7Sc7F6OalW5ysXJGI=",
       "dev": true,
       "requires": {
-        "vlq": "0.2.3"
+        "vlq": "^0.2.1"
       }
     },
     "makeerror": {
@@ -3843,7 +3843,7 @@
       "integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
       "dev": true,
       "requires": {
-        "tmpl": "1.0.4"
+        "tmpl": "1.0.x"
       }
     },
     "mem": {
@@ -3852,7 +3852,7 @@
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
       "dev": true,
       "requires": {
-        "mimic-fn": "1.1.0"
+        "mimic-fn": "^1.0.0"
       }
     },
     "merge": {
@@ -3867,19 +3867,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       }
     },
     "mime-db": {
@@ -3894,7 +3894,7 @@
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "dev": true,
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "~1.30.0"
       }
     },
     "mimic-fn": {
@@ -3909,7 +3909,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.8"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -3972,10 +3972,10 @@
       "integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
       "dev": true,
       "requires": {
-        "growly": "1.3.0",
-        "semver": "5.4.1",
-        "shellwords": "0.1.1",
-        "which": "1.3.0"
+        "growly": "^1.3.0",
+        "semver": "^5.3.0",
+        "shellwords": "^0.1.0",
+        "which": "^1.2.12"
       }
     },
     "normalize-package-data": {
@@ -3984,10 +3984,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.4.1",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -3996,7 +3996,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       }
     },
     "npm-run-path": {
@@ -4005,7 +4005,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "number-is-nan": {
@@ -4038,8 +4038,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "once": {
@@ -4048,7 +4048,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -4063,8 +4063,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "minimist": {
@@ -4087,12 +4087,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "os-homedir": {
@@ -4107,9 +4107,9 @@
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "dev": true,
       "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
       }
     },
     "os-tmpdir": {
@@ -4142,7 +4142,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.1.0"
+        "p-limit": "^1.1.0"
       }
     },
     "parse-glob": {
@@ -4151,10 +4151,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "parse-json": {
@@ -4163,7 +4163,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "parse5": {
@@ -4208,9 +4208,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "performance-now": {
@@ -4237,7 +4237,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pluralize": {
@@ -4264,8 +4264,8 @@
       "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
       "dev": true,
       "requires": {
-        "ansi-regex": "3.0.0",
-        "ansi-styles": "3.2.0"
+        "ansi-regex": "^3.0.0",
+        "ansi-styles": "^3.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -4280,7 +4280,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "^1.9.0"
           }
         }
       }
@@ -4333,8 +4333,8 @@
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -4343,7 +4343,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4352,7 +4352,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -4363,7 +4363,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -4374,9 +4374,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -4385,8 +4385,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       },
       "dependencies": {
         "find-up": {
@@ -4395,8 +4395,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-exists": {
@@ -4405,7 +4405,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         }
       }
@@ -4416,13 +4416,13 @@
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "1.0.7",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.0.3",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
@@ -4431,10 +4431,10 @@
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.3",
-        "set-immediate-shim": "1.0.1"
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "readable-stream": "^2.0.2",
+        "set-immediate-shim": "^1.0.1"
       }
     },
     "readline2": {
@@ -4443,8 +4443,8 @@
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
         "mute-stream": "0.0.5"
       }
     },
@@ -4454,7 +4454,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.4.0"
+        "resolve": "^1.1.6"
       }
     },
     "regenerator-runtime": {
@@ -4469,7 +4469,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "remove-trailing-separator": {
@@ -4496,7 +4496,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "request": {
@@ -4505,28 +4505,28 @@
       "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.6.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.1",
-        "har-validator": "5.0.3",
-        "hawk": "6.0.2",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.1",
-        "safe-buffer": "5.1.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.3.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.1.0"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "stringstream": "~0.0.5",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
     "require-directory": {
@@ -4553,8 +4553,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       }
     },
     "resolve": {
@@ -4563,7 +4563,7 @@
       "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-from": {
@@ -4578,8 +4578,8 @@
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
       }
     },
     "right-align": {
@@ -4589,7 +4589,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -4598,7 +4598,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.2"
+        "glob": "^7.0.5"
       }
     },
     "rollup": {
@@ -4613,8 +4613,8 @@
       "integrity": "sha512-dPIvH9iK9AUGRrqpARL6TTNY85BJpc5OK5PiCAnFaRe7C1boRBVRXiL0SYsYNVnyYYPl6vu0lVSb722eMSw1Eg==",
       "dev": true,
       "requires": {
-        "buble": "0.16.0",
-        "rollup-pluginutils": "2.0.1"
+        "buble": "^0.16.0",
+        "rollup-pluginutils": "^2.0.1"
       }
     },
     "rollup-pluginutils": {
@@ -4623,8 +4623,8 @@
       "integrity": "sha1-fslbNXP2VDpGpkYb2afFRFJdD8A=",
       "dev": true,
       "requires": {
-        "estree-walker": "0.3.1",
-        "micromatch": "2.3.11"
+        "estree-walker": "^0.3.0",
+        "micromatch": "^2.3.11"
       }
     },
     "rollup-watch": {
@@ -4633,9 +4633,9 @@
       "integrity": "sha512-6yjnIwfjpSrqA8IafyIu7fsEyeImNR4aDjA1bQ7KWeVuiA+Clfsx8+PGQkyABWIQzmauQ//tIJ5wAxLXsXs8qQ==",
       "dev": true,
       "requires": {
-        "chokidar": "1.7.0",
+        "chokidar": "^1.7.0",
         "require-relative": "0.8.7",
-        "rollup-pluginutils": "2.0.1"
+        "rollup-pluginutils": "^2.0.1"
       }
     },
     "run-async": {
@@ -4644,7 +4644,7 @@
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.3.0"
       }
     },
     "rx-lite": {
@@ -4654,18 +4654,18 @@
       "dev": true
     },
     "rxjs": {
-      "version": "6.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.0.0-beta.4.tgz",
-      "integrity": "sha512-H+ghJ4H2mPrugoMfgbeky0yhmOrk4y0ykRyZpYvU2za0VbE2WTKgY/9pF7HJCogPFNIyI4GqI9Ujk3Xr4XxHbQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.1.0.tgz",
+      "integrity": "sha512-lMZdl6xbHJCSb5lmnb6nOhsoBVCyoDC5LDJQK9WWyq+tsI7KnlDIZ0r0AZAlBpRPLbwQA9kzSBAZwNIZEZ+hcw==",
       "dev": true,
       "requires": {
-        "tslib": "1.9.0"
+        "tslib": "^1.9.0"
       }
     },
     "rxjs-compat": {
-      "version": "6.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/rxjs-compat/-/rxjs-compat-6.0.0-beta.4.tgz",
-      "integrity": "sha512-Cx/vlb+KS+0ibFhKeupQWSmnEd4wot4cW7iBvGjtnVm7xe110VtqJaIjglaiojm3lmtjyLEiDSqkLGDiI+bWBA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/rxjs-compat/-/rxjs-compat-6.1.0.tgz",
+      "integrity": "sha512-x5L1KQy1RqDRpPadN5iDOx71TV9Wqmlmu6OOEn3tFFgaTCB0/N+Lmby/rZHgJ6JEPzzt0nD9Zv+kS53E5JIR5g==",
       "dev": true
     },
     "safe-buffer": {
@@ -4680,14 +4680,14 @@
       "integrity": "sha512-OSJxhHO0CgPUw3lUm3GhfREAfza45smvEI9ozuFrxKG10GHVo0ryW9FK5VYlLvxj0SV7HVKHW0voYJIRu27GWg==",
       "dev": true,
       "requires": {
-        "anymatch": "1.3.2",
-        "exec-sh": "0.2.1",
-        "fb-watchman": "2.0.0",
-        "fsevents": "1.1.2",
-        "minimatch": "3.0.4",
-        "minimist": "1.2.0",
-        "walker": "1.0.7",
-        "watch": "0.18.0"
+        "anymatch": "^1.3.0",
+        "exec-sh": "^0.2.0",
+        "fb-watchman": "^2.0.0",
+        "fsevents": "^1.1.1",
+        "minimatch": "^3.0.2",
+        "minimist": "^1.1.1",
+        "walker": "~1.0.5",
+        "watch": "~0.18.0"
       }
     },
     "sax": {
@@ -4720,7 +4720,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -4735,9 +4735,9 @@
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "interpret": "1.0.4",
-        "rechoir": "0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       }
     },
     "shellwords": {
@@ -4770,7 +4770,7 @@
       "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
       "dev": true,
       "requires": {
-        "hoek": "4.2.0"
+        "hoek": "4.x.x"
       }
     },
     "source-map": {
@@ -4785,7 +4785,7 @@
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "0.5.7"
+        "source-map": "^0.5.6"
       }
     },
     "spdx-correct": {
@@ -4794,7 +4794,7 @@
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "^1.0.2"
       }
     },
     "spdx-expression-parse": {
@@ -4821,14 +4821,14 @@
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       }
     },
     "string-length": {
@@ -4837,8 +4837,8 @@
       "integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
       "dev": true,
       "requires": {
-        "astral-regex": "1.0.0",
-        "strip-ansi": "4.0.0"
+        "astral-regex": "^1.0.0",
+        "strip-ansi": "^4.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -4853,7 +4853,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -4864,9 +4864,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string_decoder": {
@@ -4875,7 +4875,7 @@
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "~5.1.0"
       }
     },
     "stringstream": {
@@ -4890,7 +4890,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -4929,12 +4929,12 @@
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "chalk": "1.1.3",
-        "lodash": "4.17.4",
+        "ajv": "^4.7.0",
+        "ajv-keywords": "^1.0.0",
+        "chalk": "^1.1.1",
+        "lodash": "^4.0.0",
         "slice-ansi": "0.0.4",
-        "string-width": "2.1.1"
+        "string-width": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -4955,8 +4955,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -4965,7 +4965,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -4976,11 +4976,11 @@
       "integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "micromatch": "2.3.11",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "require-main-filename": "1.0.1"
+        "arrify": "^1.0.1",
+        "micromatch": "^2.3.11",
+        "object-assign": "^4.1.0",
+        "read-pkg-up": "^1.0.1",
+        "require-main-filename": "^1.0.1"
       }
     },
     "text-table": {
@@ -5019,7 +5019,7 @@
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "dev": true,
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "tr46": {
@@ -5052,7 +5052,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -5068,7 +5068,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "typedarray": {
@@ -5090,9 +5090,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       },
       "dependencies": {
         "yargs": {
@@ -5102,9 +5102,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
+            "camelcase": "^1.0.2",
+            "cliui": "^2.1.0",
+            "decamelize": "^1.0.0",
             "window-size": "0.1.0"
           }
         }
@@ -5123,7 +5123,7 @@
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.0"
       }
     },
     "util-deprecate": {
@@ -5144,8 +5144,8 @@
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
       }
     },
     "verror": {
@@ -5154,9 +5154,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "vlq": {
@@ -5177,7 +5177,7 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "dev": true,
       "requires": {
-        "makeerror": "1.0.11"
+        "makeerror": "1.0.x"
       }
     },
     "watch": {
@@ -5186,8 +5186,8 @@
       "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
       "dev": true,
       "requires": {
-        "exec-sh": "0.2.1",
-        "minimist": "1.2.0"
+        "exec-sh": "^0.2.0",
+        "minimist": "^1.2.0"
       }
     },
     "webidl-conversions": {
@@ -5211,8 +5211,8 @@
       "integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
       "dev": true,
       "requires": {
-        "tr46": "0.0.3",
-        "webidl-conversions": "3.0.1"
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       },
       "dependencies": {
         "webidl-conversions": {
@@ -5229,7 +5229,7 @@
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "which-module": {
@@ -5257,8 +5257,8 @@
       "integrity": "sha512-DHRiUggxtbruaTwnLDm2/BRDKZIoOYvrgYUj5Bam4fU6Gtvc0FaEyoswFPBjMXAweGW2H4BDNIpy//1yXXuaqQ==",
       "dev": true,
       "requires": {
-        "errno": "0.1.4",
-        "xtend": "4.0.1"
+        "errno": "^0.1.4",
+        "xtend": "^4.0.1"
       }
     },
     "wrap-ansi": {
@@ -5267,8 +5267,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       }
     },
     "wrappy": {
@@ -5283,7 +5283,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       }
     },
     "write-file-atomic": {
@@ -5292,9 +5292,9 @@
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
+        "graceful-fs": "^4.1.11",
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.2"
       }
     },
     "xml-name-validator": {
@@ -5327,19 +5327,19 @@
       "integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "2.1.0",
-        "read-pkg-up": "2.0.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "7.0.0"
+        "camelcase": "^4.1.0",
+        "cliui": "^3.2.0",
+        "decamelize": "^1.1.1",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^2.0.0",
+        "read-pkg-up": "^2.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1",
+        "yargs-parser": "^7.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -5360,9 +5360,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           },
           "dependencies": {
             "string-width": {
@@ -5371,9 +5371,9 @@
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
               }
             }
           }
@@ -5384,10 +5384,10 @@
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "path-type": {
@@ -5396,7 +5396,7 @@
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
           "dev": true,
           "requires": {
-            "pify": "2.3.0"
+            "pify": "^2.0.0"
           }
         },
         "read-pkg": {
@@ -5405,9 +5405,9 @@
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
           "dev": true,
           "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
           }
         },
         "read-pkg-up": {
@@ -5416,8 +5416,8 @@
           "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
           "dev": true,
           "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
           }
         },
         "string-width": {
@@ -5426,8 +5426,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           },
           "dependencies": {
             "is-fullwidth-code-point": {
@@ -5442,7 +5442,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
               }
             }
           }
@@ -5455,7 +5455,7 @@
       "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
       "dev": true,
       "requires": {
-        "camelcase": "4.1.0"
+        "camelcase": "^4.1.0"
       },
       "dependencies": {
         "camelcase": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "rollup": "^0.50.0",
     "rollup-plugin-buble": "^0.16.0",
     "rollup-watch": "^4.3.1",
-    "rxjs": "^6.0.0-beta.3˝∏˝",
+    "rxjs": "^6.0.0-beta.3",
     "rxjs-compat": "^6.0.0-beta.1",
     "typescript": "^2.5.2",
     "vue": "^2.5.0"

--- a/package.json
+++ b/package.json
@@ -1,33 +1,30 @@
 {
   "name": "vue-rx",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "RxJS bindings for Vue",
   "main": "dist/vue-rx.js",
-  "files": [
-    "dist",
-    "types/*.d.ts"
-  ],
+  "files": ["dist", "types/*.d.ts"],
   "typings": "types/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vuejs/vue-rx.git"
+    "url":
+      "git+https://github.com/vuejs/vue-rx.git"
   },
-  "keywords": [
-    "vue",
-    "rx",
-    "rxjs"
-  ],
+  "keywords": ["vue", "rx", "rxjs"],
   "author": "Evan You",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/vuejs/vue-rx/issues"
+    "url":
+      "https://github.com/vuejs/vue-rx/issues"
   },
-  "homepage": "https://github.com/vuejs/vue-rx#readme",
+  "homepage":
+    "https://github.com/vuejs/vue-rx#readme",
   "scripts": {
     "dev": "rollup -c rollup.config.js -w",
     "build": "rollup -c rollup.config.js",
     "lint": "eslint src test example --fix",
-    "test": "npm run test:unit && npm run test:types",
+    "test":
+      "npm run test:unit && npm run test:types",
     "test:unit": "jest",
     "test:types": "tsc -p types/test",
     "dev:test": "jest --watch",
@@ -43,14 +40,13 @@
     "rollup": "^0.50.0",
     "rollup-plugin-buble": "^0.16.0",
     "rollup-watch": "^4.3.1",
-    "rxjs": "^5.2.0",
+    "rxjs": "^6.0.0-beta.3˝∏˝",
+    "rxjs-compat": "^6.0.0-beta.1",
     "typescript": "^2.5.2",
     "vue": "^2.5.0"
   },
   "eslintConfig": {
     "root": true,
-    "extends": [
-      "plugin:vue-libs/recommended"
-    ]
+    "extends": ["plugin:vue-libs/recommended"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,20 +3,13 @@
   "version": "6.0.0",
   "description": "RxJS bindings for Vue",
   "main": "dist/vue-rx.js",
-  "files": [
-    "dist",
-    "types/*.d.ts"
-  ],
+  "files": ["dist", "types/*.d.ts"],
   "typings": "types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/vuejs/vue-rx.git"
   },
-  "keywords": [
-    "vue",
-    "rx",
-    "rxjs"
-  ],
+  "keywords": ["vue", "rx", "rxjs"],
   "author": "Evan You",
   "license": "MIT",
   "bugs": {
@@ -43,15 +36,13 @@
     "rollup": "^0.50.0",
     "rollup-plugin-buble": "^0.16.0",
     "rollup-watch": "^4.3.1",
-    "rxjs": "^6.0.0-beta.4",
-    "rxjs-compat": "^6.0.0-beta.4",
+    "rxjs": "^6.0.0",
+    "rxjs-compat": "^6.0.0",
     "typescript": "^2.5.2",
     "vue": "^2.5.0"
   },
   "eslintConfig": {
     "root": true,
-    "extends": [
-      "plugin:vue-libs/recommended"
-    ]
+    "extends": ["plugin:vue-libs/recommended"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,26 +7,22 @@
   "typings": "types/index.d.ts",
   "repository": {
     "type": "git",
-    "url":
-      "git+https://github.com/vuejs/vue-rx.git"
+    "url": "git+https://github.com/vuejs/vue-rx.git"
   },
   "keywords": ["vue", "rx", "rxjs"],
   "author": "Evan You",
   "license": "MIT",
   "bugs": {
-    "url":
-      "https://github.com/vuejs/vue-rx/issues"
+    "url": "https://github.com/vuejs/vue-rx/issues"
   },
-  "homepage":
-    "https://github.com/vuejs/vue-rx#readme",
+  "homepage": "https://github.com/vuejs/vue-rx#readme",
   "scripts": {
     "dev": "rollup -c rollup.config.js -w",
     "build": "rollup -c rollup.config.js",
     "lint": "eslint src test example --fix",
-    "test":
-      "npm run test:unit && npm run test:types",
+    "test": "npm run test:unit && npm run test:types",
     "test:unit": "jest",
-    "test:types": "tsc -p types/test",
+    "test:types": "tsc -p types",
     "dev:test": "jest --watch",
     "prebuild": "npm run lint",
     "pretest": "npm run build",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "rollup": "^0.50.0",
     "rollup-plugin-buble": "^0.16.0",
     "rollup-watch": "^4.3.1",
-    "rxjs": "^6.0.0-beta.3",
-    "rxjs-compat": "^6.0.0-beta.1",
+    "rxjs": "^6.0.0-beta.4",
+    "rxjs-compat": "^6.0.0-beta.4",
     "typescript": "^2.5.2",
     "vue": "^2.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,13 +3,20 @@
   "version": "6.0.0",
   "description": "RxJS bindings for Vue",
   "main": "dist/vue-rx.js",
-  "files": ["dist", "types/*.d.ts"],
+  "files": [
+    "dist",
+    "types/*.d.ts"
+  ],
   "typings": "types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/vuejs/vue-rx.git"
   },
-  "keywords": ["vue", "rx", "rxjs"],
+  "keywords": [
+    "vue",
+    "rx",
+    "rxjs"
+  ],
   "author": "Evan You",
   "license": "MIT",
   "bugs": {
@@ -43,6 +50,8 @@
   },
   "eslintConfig": {
     "root": true,
-    "extends": ["plugin:vue-libs/recommended"]
+    "extends": [
+      "plugin:vue-libs/recommended"
+    ]
   }
 }

--- a/src/directives/stream.js
+++ b/src/directives/stream.js
@@ -16,12 +16,9 @@ export default {
       handle = { subject: handle }
     } else if (!handle || !isSubject(handle.subject)) {
       warn(
-        'Invalid Subject found in directive with key "' +
-          streamName +
-          '".' +
-          streamName +
-          ' should be an instance of Rx.Subject or have the ' +
-          'type { subject: Rx.Subject, data: any }.',
+        'Invalid Subject found in directive with key "' + streamName + '".' +
+        streamName + ' should be an instance of Rx.Subject or have the ' +
+        'type { subject: Rx.Subject, data: any }.',
         vnode.context
       )
       return
@@ -33,35 +30,32 @@ export default {
     }
 
     var modifiersExists = Object.keys(modifiersFuncs).filter(
-      key => modifiers[key]
+        key => modifiers[key]
     )
 
     const subject = handle.subject
     const next = (subject.next || subject.onNext).bind(subject)
 
     if (!modifiers.native && vnode.componentInstance) {
-      handle.subscription = vnode.componentInstance
-        .$eventToObservable(event)
-        .subscribe(e => {
-          modifiersExists.forEach(mod => modifiersFuncs[mod](e))
-          next({
-            event: e,
-            data: handle.data
-          })
+      handle.subscription = vnode.componentInstance.$eventToObservable(event).subscribe(e => {
+        modifiersExists.forEach(mod => modifiersFuncs[mod](e))
+        next({
+          event: e,
+          data: handle.data
         })
+      })
     } else {
       const fromEvent = Rx.fromEvent || Rx.Observable.fromEvent
       if (!fromEvent) {
         warn(
-          `Please import 'rxjs/operators/fromEvent' and pass to the Vue.use plugin install` +
-            `v-stream directive requires Rx.Observable.fromEvent method. `,
+          `No 'fromEvent' method on Observable class. ` +
+          `v-stream directive requires Rx.Observable.fromEvent method. ` +
+          `Try import 'rxjs/add/observable/fromEvent' for ${streamName}`,
           vnode.context
         )
         return
       }
-      const fromEventArgs = handle.options
-        ? [el, event, handle.options]
-        : [el, event]
+      const fromEventArgs = handle.options ? [el, event, handle.options] : [el, event]
       handle.subscription = fromEvent(...fromEventArgs).subscribe(e => {
         modifiersExists.forEach(mod => modifiersFuncs[mod](e))
         next({

--- a/src/directives/stream.js
+++ b/src/directives/stream.js
@@ -1,11 +1,4 @@
-import {
-  Rx,
-  hasRx,
-  isSubject,
-  warn,
-  getKey,
-  unsub
-} from '../util'
+import { Rx, hasRx, isSubject, warn, getKey, unsub } from '../util'
 
 export default {
   // Example ./example/counter_dir.html
@@ -21,10 +14,7 @@ export default {
 
     if (isSubject(handle)) {
       handle = { subject: handle }
-    } else if (
-      !handle ||
-      !isSubject(handle.subject)
-    ) {
+    } else if (!handle || !isSubject(handle.subject)) {
       warn(
         'Invalid Subject found in directive with key "' +
           streamName +
@@ -42,33 +32,25 @@ export default {
       prevent: e => e.preventDefault()
     }
 
-    var modifiersExists = Object.keys(
-      modifiersFuncs
-    ).filter(key => modifiers[key])
+    var modifiersExists = Object.keys(modifiersFuncs).filter(
+      key => modifiers[key]
+    )
 
     const subject = handle.subject
-    const next = (
-      subject.next || subject.onNext
-    ).bind(subject)
+    const next = (subject.next || subject.onNext).bind(subject)
 
-    if (
-      !modifiers.native &&
-      vnode.componentInstance
-    ) {
+    if (!modifiers.native && vnode.componentInstance) {
       handle.subscription = vnode.componentInstance
         .$eventToObservable(event)
         .subscribe(e => {
-          modifiersExists.forEach(mod =>
-            modifiersFuncs[mod](e)
-          )
+          modifiersExists.forEach(mod => modifiersFuncs[mod](e))
           next({
             event: e,
             data: handle.data
           })
         })
     } else {
-      const fromEvent =
-        Rx.fromEvent || Rx.Observable.fromEvent
+      const fromEvent = Rx.fromEvent || Rx.Observable.fromEvent
       if (!fromEvent) {
         warn(
           `Please import 'rxjs/operators/fromEvent' and pass to the Vue.use plugin install` +
@@ -80,12 +62,8 @@ export default {
       const fromEventArgs = handle.options
         ? [el, event, handle.options]
         : [el, event]
-      handle.subscription = fromEvent(
-        ...fromEventArgs
-      ).subscribe(e => {
-        modifiersExists.forEach(mod =>
-          modifiersFuncs[mod](e)
-        )
+      handle.subscription = fromEvent(...fromEventArgs).subscribe(e => {
+        modifiersExists.forEach(mod => modifiersFuncs[mod](e))
         next({
           event: e,
           data: handle.data
@@ -94,30 +72,21 @@ export default {
 
       // store handle on element with a unique key for identifying
       // multiple v-stream directives on the same node
-      ;(el._rxHandles || (el._rxHandles = {}))[
-        getKey(binding)
-      ] = handle
+      ;(el._rxHandles || (el._rxHandles = {}))[getKey(binding)] = handle
     }
   },
 
   update (el, binding) {
     const handle = binding.value
-    const _handle =
-      el._rxHandles &&
-      el._rxHandles[getKey(binding)]
-    if (
-      _handle &&
-      handle &&
-      isSubject(handle.subject)
-    ) {
+    const _handle = el._rxHandles && el._rxHandles[getKey(binding)]
+    if (_handle && handle && isSubject(handle.subject)) {
       _handle.data = handle.data
     }
   },
 
   unbind (el, binding) {
     const key = getKey(binding)
-    const handle =
-      el._rxHandles && el._rxHandles[key]
+    const handle = el._rxHandles && el._rxHandles[key]
     if (handle) {
       unsub(handle.subscription)
       el._rxHandles[key] = null

--- a/src/directives/stream.js
+++ b/src/directives/stream.js
@@ -1,4 +1,11 @@
-import { Rx, hasRx, isSubject, warn, getKey, unsub } from '../util'
+import {
+  Rx,
+  hasRx,
+  isSubject,
+  warn,
+  getKey,
+  unsub
+} from '../util'
 
 export default {
   // Example ./example/counter_dir.html
@@ -14,11 +21,17 @@ export default {
 
     if (isSubject(handle)) {
       handle = { subject: handle }
-    } else if (!handle || !isSubject(handle.subject)) {
+    } else if (
+      !handle ||
+      !isSubject(handle.subject)
+    ) {
       warn(
-        'Invalid Subject found in directive with key "' + streamName + '".' +
-        streamName + ' should be an instance of Rx.Subject or have the ' +
-        'type { subject: Rx.Subject, data: any }.',
+        'Invalid Subject found in directive with key "' +
+          streamName +
+          '".' +
+          streamName +
+          ' should be an instance of Rx.Subject or have the ' +
+          'type { subject: Rx.Subject, data: any }.',
         vnode.context
       )
       return
@@ -29,34 +42,50 @@ export default {
       prevent: e => e.preventDefault()
     }
 
-    var modifiersExists = Object.keys(modifiersFuncs).filter(
-        key => modifiers[key]
-    )
+    var modifiersExists = Object.keys(
+      modifiersFuncs
+    ).filter(key => modifiers[key])
 
     const subject = handle.subject
-    const next = (subject.next || subject.onNext).bind(subject)
+    const next = (
+      subject.next || subject.onNext
+    ).bind(subject)
 
-    if (!modifiers.native && vnode.componentInstance) {
-      handle.subscription = vnode.componentInstance.$eventToObservable(event).subscribe(e => {
-        modifiersExists.forEach(mod => modifiersFuncs[mod](e))
-        next({
-          event: e,
-          data: handle.data
+    if (
+      !modifiers.native &&
+      vnode.componentInstance
+    ) {
+      handle.subscription = vnode.componentInstance
+        .$eventToObservable(event)
+        .subscribe(e => {
+          modifiersExists.forEach(mod =>
+            modifiersFuncs[mod](e)
+          )
+          next({
+            event: e,
+            data: handle.data
+          })
         })
-      })
     } else {
-      if (!Rx.Observable.fromEvent) {
+      const fromEvent =
+        Rx.fromEvent || Rx.Observable.fromEvent
+      if (!fromEvent) {
         warn(
-          `No 'fromEvent' method on Observable class. ` +
-          `v-stream directive requires Rx.Observable.fromEvent method. ` +
-          `Try import 'rxjs/add/observable/fromEvent' for ${streamName}`,
+          `Please import 'rxjs/operators/fromEvent' and pass to the Vue.use plugin install` +
+            `v-stream directive requires Rx.Observable.fromEvent method. `,
           vnode.context
         )
         return
       }
-      const fromEventArgs = handle.options ? [el, event, handle.options] : [el, event]
-      handle.subscription = Rx.Observable.fromEvent(...fromEventArgs).subscribe(e => {
-        modifiersExists.forEach(mod => modifiersFuncs[mod](e))
+      const fromEventArgs = handle.options
+        ? [el, event, handle.options]
+        : [el, event]
+      handle.subscription = fromEvent(
+        ...fromEventArgs
+      ).subscribe(e => {
+        modifiersExists.forEach(mod =>
+          modifiersFuncs[mod](e)
+        )
         next({
           event: e,
           data: handle.data
@@ -65,21 +94,30 @@ export default {
 
       // store handle on element with a unique key for identifying
       // multiple v-stream directives on the same node
-      ;(el._rxHandles || (el._rxHandles = {}))[getKey(binding)] = handle
+      ;(el._rxHandles || (el._rxHandles = {}))[
+        getKey(binding)
+      ] = handle
     }
   },
 
   update (el, binding) {
     const handle = binding.value
-    const _handle = el._rxHandles && el._rxHandles[getKey(binding)]
-    if (_handle && handle && isSubject(handle.subject)) {
+    const _handle =
+      el._rxHandles &&
+      el._rxHandles[getKey(binding)]
+    if (
+      _handle &&
+      handle &&
+      isSubject(handle.subject)
+    ) {
       _handle.data = handle.data
     }
   },
 
   unbind (el, binding) {
     const key = getKey(binding)
-    const handle = el._rxHandles && el._rxHandles[key]
+    const handle =
+      el._rxHandles && el._rxHandles[key]
     if (handle) {
       unsub(handle.subscription)
       el._rxHandles[key] = null

--- a/src/methods/createObservableMethod.js
+++ b/src/methods/createObservableMethod.js
@@ -17,8 +17,8 @@ export default function createObservableMethod (methodName, passContext) {
   if (!share) {
     warn(
       `No 'share' operator. ` +
-        `$createObservableMethod returns a shared hot observable. ` +
-        `Try import 'rxjs/add/operator/share' for creating ${methodName}`,
+      `$createObservableMethod returns a shared hot observable. ` +
+      `Try import 'rxjs/add/operator/share' for creating ${methodName}`,
       vm
     )
     return
@@ -27,8 +27,8 @@ export default function createObservableMethod (methodName, passContext) {
   if (vm[methodName] !== undefined) {
     warn(
       'Potential bug: ' +
-        `Method ${methodName} already defined on vm and has been overwritten by $createObservableMethod.` +
-        String(vm[methodName]),
+      `Method ${methodName} already defined on vm and has been overwritten by $createObservableMethod.` +
+      String(vm[methodName]),
       vm
     )
   }
@@ -53,7 +53,6 @@ export default function createObservableMethod (methodName, passContext) {
   }
 
   // Must be a hot stream otherwise function context may overwrite over and over again
-
   if (Rx.share) {
     return Rx.Observable.create(creator).pipe(share())
   }

--- a/src/methods/createObservableMethod.js
+++ b/src/methods/createObservableMethod.js
@@ -7,17 +7,13 @@ import { Rx, hasRx, warn } from '../util'
  * @param {Boolean} [passContext] Append the call context at the end of emit data?
  * @return {Observable} Hot stream
  */
-export default function createObservableMethod (
-  methodName,
-  passContext
-) {
+export default function createObservableMethod (methodName, passContext) {
   if (!hasRx()) {
     return
   }
   const vm = this
 
-  const share =
-    Rx.share || Rx.Observable.prototype.share
+  const share = Rx.share || Rx.Observable.prototype.share
   if (!share) {
     warn(
       `No 'share' operator. ` +
@@ -59,9 +55,7 @@ export default function createObservableMethod (
   // Must be a hot stream otherwise function context may overwrite over and over again
 
   if (Rx.share) {
-    return Rx.Observable.create(creator).pipe(
-      share()
-    )
+    return Rx.Observable.create(creator).pipe(share())
   }
   return Rx.Observable.create(creator).share()
 }

--- a/src/methods/createObservableMethod.js
+++ b/src/methods/createObservableMethod.js
@@ -7,17 +7,22 @@ import { Rx, hasRx, warn } from '../util'
  * @param {Boolean} [passContext] Append the call context at the end of emit data?
  * @return {Observable} Hot stream
  */
-export default function createObservableMethod (methodName, passContext) {
+export default function createObservableMethod (
+  methodName,
+  passContext
+) {
   if (!hasRx()) {
     return
   }
   const vm = this
 
-  if (!Rx.Observable.prototype.share) {
+  const share =
+    Rx.share || Rx.Observable.prototype.share
+  if (!share) {
     warn(
       `No 'share' operator. ` +
-      `$createObservableMethod returns a shared hot observable. ` +
-      `Try import 'rxjs/add/operator/share' for creating ${methodName}`,
+        `$createObservableMethod returns a shared hot observable. ` +
+        `Try import 'rxjs/add/operator/share' for creating ${methodName}`,
       vm
     )
     return
@@ -26,8 +31,8 @@ export default function createObservableMethod (methodName, passContext) {
   if (vm[methodName] !== undefined) {
     warn(
       'Potential bug: ' +
-      `Method ${methodName} already defined on vm and has been overwritten by $createObservableMethod.` +
-      String(vm[methodName]),
+        `Method ${methodName} already defined on vm and has been overwritten by $createObservableMethod.` +
+        String(vm[methodName]),
       vm
     )
   }
@@ -52,5 +57,11 @@ export default function createObservableMethod (methodName, passContext) {
   }
 
   // Must be a hot stream otherwise function context may overwrite over and over again
+
+  if (Rx.share) {
+    return Rx.Observable.create(creator).pipe(
+      share()
+    )
+  }
   return Rx.Observable.create(creator).share()
 }

--- a/test/v5.spec.js
+++ b/test/v5.spec.js
@@ -1,24 +1,24 @@
 /* eslint-env jest */
 
-"use strict"
+'use strict'
 
-const Vue = require("vue/dist/vue.js")
-const VueRx = require("../dist/vue-rx.js")
+const Vue = require('vue/dist/vue.js')
+const VueRx = require('../dist/vue-rx.js')
 
 // library
-const Observable = require("rxjs-compat/Observable").Observable
-const Subject = require("rxjs-compat/Subject").Subject
-const Subscription = require("rxjs-compat/Subscription").Subscription
-require("rxjs-compat/add/observable/fromEvent")
-require("rxjs-compat/add/operator/share")
+const Observable = require('rxjs-compat/Observable').Observable
+const Subject = require('rxjs-compat/Subject').Subject
+const Subscription = require('rxjs-compat/Subscription').Subscription
+require('rxjs-compat/add/observable/fromEvent')
+require('rxjs-compat/add/operator/share')
 
 // user
-require("rxjs-compat/add/operator/map")
-require("rxjs-compat/add/operator/startWith")
-require("rxjs-compat/add/operator/scan")
-require("rxjs-compat/add/operator/pluck")
-require("rxjs-compat/add/operator/merge")
-require("rxjs-compat/add/operator/filter")
+require('rxjs-compat/add/operator/map')
+require('rxjs-compat/add/operator/startWith')
+require('rxjs-compat/add/operator/scan')
+require('rxjs-compat/add/operator/pluck')
+require('rxjs-compat/add/operator/merge')
+require('rxjs-compat/add/operator/filter')
 
 const miniRx = {
   Observable,
@@ -31,7 +31,7 @@ Vue.use(VueRx, miniRx)
 
 const nextTick = Vue.nextTick
 
-function mock() {
+function mock () {
   let observer
   const observable = Observable.create(_observer => {
     observer = _observer
@@ -42,17 +42,17 @@ function mock() {
   }
 }
 
-function trigger(target, event) {
-  var e = document.createEvent("HTMLEvents")
+function trigger (target, event) {
+  var e = document.createEvent('HTMLEvents')
   e.initEvent(event, true, true)
   target.dispatchEvent(e)
 }
 
-function click(target) {
-  trigger(target, "click")
+function click (target) {
+  trigger(target, 'click')
 }
 
-test("expose $observables", () => {
+test('expose $observables', () => {
   const { ob, next } = mock()
 
   const vm = new Vue({
@@ -72,49 +72,49 @@ test("expose $observables", () => {
   expect(results).toEqual([0, 1, 2, 3])
 })
 
-test("bind subscriptions to render", done => {
+test('bind subscriptions to render', done => {
   const { ob, next } = mock()
 
   const vm = new Vue({
     subscriptions: {
-      hello: ob.startWith("foo")
+      hello: ob.startWith('foo')
     },
-    render(h) {
-      return h("div", this.hello)
+    render (h) {
+      return h('div', this.hello)
     }
   }).$mount()
 
-  expect(vm.$el.textContent).toBe("foo")
+  expect(vm.$el.textContent).toBe('foo')
 
-  next("bar")
+  next('bar')
   nextTick(() => {
-    expect(vm.$el.textContent).toBe("bar")
+    expect(vm.$el.textContent).toBe('bar')
     done()
   })
 })
 
-test("subscriptions() has access to component state", () => {
+test('subscriptions() has access to component state', () => {
   const { ob } = mock()
 
   const vm = new Vue({
     data: {
-      foo: "FOO"
+      foo: 'FOO'
     },
-    props: ["bar"],
+    props: ['bar'],
     propsData: {
-      bar: "BAR"
+      bar: 'BAR'
     },
-    subscriptions() {
+    subscriptions () {
       return {
         hello: ob.startWith(this.foo + this.bar)
       }
     },
-    render(h) {
-      return h("div", this.hello)
+    render (h) {
+      return h('div', this.hello)
     }
   }).$mount()
 
-  expect(vm.$el.textContent).toBe("FOOBAR")
+  expect(vm.$el.textContent).toBe('FOOBAR')
 })
 
 /* I believe this is a breaking change of v6 :/
@@ -142,7 +142,7 @@ test("subscriptions() can throw error properly", done => {
 })
 */
 
-test("v-stream directive (basic)", done => {
+test('v-stream directive (basic)', done => {
   const vm = new Vue({
     template: `
       <div>
@@ -150,8 +150,8 @@ test("v-stream directive (basic)", done => {
         <button v-stream:click="click$">+</button>
       </div>
     `,
-    domStreams: ["click$"],
-    subscriptions() {
+    domStreams: ['click$'],
+    subscriptions () {
       return {
         count: this.click$
           .map(() => 1)
@@ -161,15 +161,15 @@ test("v-stream directive (basic)", done => {
     }
   }).$mount()
 
-  expect(vm.$el.querySelector("span").textContent).toBe("0")
-  click(vm.$el.querySelector("button"))
+  expect(vm.$el.querySelector('span').textContent).toBe('0')
+  click(vm.$el.querySelector('button'))
   nextTick(() => {
-    expect(vm.$el.querySelector("span").textContent).toBe("1")
+    expect(vm.$el.querySelector('span').textContent).toBe('1')
     done()
   })
 })
 
-test("v-stream directive (with .native modify)", done => {
+test('v-stream directive (with .native modify)', done => {
   const vm = new Vue({
     template: `
       <div>
@@ -180,15 +180,15 @@ test("v-stream directive (with .native modify)", done => {
     `,
     components: {
       myButton: {
-        template: "<button>MyButton</button>"
+        template: '<button>MyButton</button>'
       }
     },
-    domStreams: ["clickNative$", "click$"],
-    subscriptions() {
+    domStreams: ['clickNative$', 'click$'],
+    subscriptions () {
       return {
         count: this.clickNative$
           .merge(this.click$)
-          .filter(e => e.event.target && e.event.target.id === "btn-native")
+          .filter(e => e.event.target && e.event.target.id === 'btn-native')
           .map(() => 1)
           .startWith(0)
           .scan((total, change) => total + change)
@@ -196,17 +196,17 @@ test("v-stream directive (with .native modify)", done => {
     }
   }).$mount()
 
-  expect(vm.$el.querySelector("span").textContent).toBe("0")
-  click(vm.$el.querySelector("#btn"))
-  click(vm.$el.querySelector("#btn"))
-  click(vm.$el.querySelector("#btn-native"))
+  expect(vm.$el.querySelector('span').textContent).toBe('0')
+  click(vm.$el.querySelector('#btn'))
+  click(vm.$el.querySelector('#btn'))
+  click(vm.$el.querySelector('#btn-native'))
   nextTick(() => {
-    expect(vm.$el.querySelector("span").textContent).toBe("1")
+    expect(vm.$el.querySelector('span').textContent).toBe('1')
     done()
   })
 })
 
-test("v-stream directive (with .stop, .prevent modify)", done => {
+test('v-stream directive (with .stop, .prevent modify)', done => {
   const vm = new Vue({
     template: `
       <form>
@@ -215,8 +215,8 @@ test("v-stream directive (with .stop, .prevent modify)", done => {
         <button id="btn-prevent" type="submit" v-stream:click.prevent="clickPrevent$">Submit</button>
       </form>
     `,
-    domStreams: ["clickStop$", "clickPrevent$"],
-    subscriptions() {
+    domStreams: ['clickStop$', 'clickPrevent$'],
+    subscriptions () {
       return {
         stoped: this.clickStop$.map(x => x.event.cancelBubble),
         prevented: this.clickPrevent$.map(x => x.event.defaultPrevented)
@@ -224,15 +224,15 @@ test("v-stream directive (with .stop, .prevent modify)", done => {
     }
   }).$mount()
 
-  click(vm.$el.querySelector("#btn-stop"))
-  click(vm.$el.querySelector("#btn-prevent"))
+  click(vm.$el.querySelector('#btn-stop'))
+  click(vm.$el.querySelector('#btn-prevent'))
   nextTick(() => {
-    expect(vm.$el.querySelector("span").textContent).toBe("true true")
+    expect(vm.$el.querySelector('span').textContent).toBe('true true')
     done()
   })
 })
 
-test("v-stream directive (with data)", done => {
+test('v-stream directive (with data)', done => {
   const vm = new Vue({
     data: {
       delta: -1
@@ -243,33 +243,33 @@ test("v-stream directive (with data)", done => {
         <button v-stream:click="{ subject: click$, data: delta }">+</button>
       </div>
     `,
-    domStreams: ["click$"],
-    subscriptions() {
+    domStreams: ['click$'],
+    subscriptions () {
       return {
         count: this.click$
-          .pluck("data")
+          .pluck('data')
           .startWith(0)
           .scan((total, change) => total + change)
       }
     }
   }).$mount()
 
-  expect(vm.$el.querySelector("span").textContent).toBe("0")
-  click(vm.$el.querySelector("button"))
+  expect(vm.$el.querySelector('span').textContent).toBe('0')
+  click(vm.$el.querySelector('button'))
   nextTick(() => {
-    expect(vm.$el.querySelector("span").textContent).toBe("-1")
+    expect(vm.$el.querySelector('span').textContent).toBe('-1')
     vm.delta = 1
     nextTick(() => {
-      click(vm.$el.querySelector("button"))
+      click(vm.$el.querySelector('button'))
       nextTick(() => {
-        expect(vm.$el.querySelector("span").textContent).toBe("0")
+        expect(vm.$el.querySelector('span').textContent).toBe('0')
         done()
       })
     })
   })
 })
 
-test("v-stream directive (multiple bindings on same node)", done => {
+test('v-stream directive (multiple bindings on same node)', done => {
   const vm = new Vue({
     template: `
       <div>
@@ -279,30 +279,30 @@ test("v-stream directive (multiple bindings on same node)", done => {
           v-stream:keyup="{ subject: plus$, data: -1 }">+</button>
       </div>
     `,
-    domStreams: ["plus$"],
-    subscriptions() {
+    domStreams: ['plus$'],
+    subscriptions () {
       return {
         count: this.plus$
-          .pluck("data")
+          .pluck('data')
           .startWith(0)
           .scan((total, change) => total + change)
       }
     }
   }).$mount()
 
-  expect(vm.$el.querySelector("span").textContent).toBe("0")
-  click(vm.$el.querySelector("button"))
+  expect(vm.$el.querySelector('span').textContent).toBe('0')
+  click(vm.$el.querySelector('button'))
   nextTick(() => {
-    expect(vm.$el.querySelector("span").textContent).toBe("1")
-    trigger(vm.$el.querySelector("button"), "keyup")
+    expect(vm.$el.querySelector('span').textContent).toBe('1')
+    trigger(vm.$el.querySelector('button'), 'keyup')
     nextTick(() => {
-      expect(vm.$el.querySelector("span").textContent).toBe("0")
+      expect(vm.$el.querySelector('span').textContent).toBe('0')
       done()
     })
   })
 })
 
-test("$fromDOMEvent()", done => {
+test('$fromDOMEvent()', done => {
   const vm = new Vue({
     template: `
       <div>
@@ -310,8 +310,8 @@ test("$fromDOMEvent()", done => {
         <button>+</button>
       </div>
     `,
-    subscriptions() {
-      const click$ = this.$fromDOMEvent("button", "click")
+    subscriptions () {
+      const click$ = this.$fromDOMEvent('button', 'click')
       return {
         count: click$
           .map(() => 1)
@@ -322,15 +322,15 @@ test("$fromDOMEvent()", done => {
   }).$mount()
 
   document.body.appendChild(vm.$el)
-  expect(vm.$el.querySelector("span").textContent).toBe("0")
-  click(vm.$el.querySelector("button"))
+  expect(vm.$el.querySelector('span').textContent).toBe('0')
+  click(vm.$el.querySelector('button'))
   nextTick(() => {
-    expect(vm.$el.querySelector("span").textContent).toBe("1")
+    expect(vm.$el.querySelector('span').textContent).toBe('1')
     done()
   })
 })
 
-test("$watchAsObservable()", done => {
+test('$watchAsObservable()', done => {
   const vm = new Vue({
     data: {
       count: 0
@@ -338,7 +338,7 @@ test("$watchAsObservable()", done => {
   })
 
   const results = []
-  vm.$watchAsObservable("count").subscribe(change => {
+  vm.$watchAsObservable('count').subscribe(change => {
     results.push(change)
   })
 
@@ -356,11 +356,11 @@ test("$watchAsObservable()", done => {
   })
 })
 
-test("$subscribeTo()", () => {
+test('$subscribeTo()', () => {
   const { ob, next } = mock()
   const results = []
   const vm = new Vue({
-    created() {
+    created () {
       this.$subscribeTo(ob, count => {
         results.push(count)
       })
@@ -375,32 +375,32 @@ test("$subscribeTo()", () => {
   expect(results).toEqual([1]) // should not trigger anymore
 })
 
-test("$eventToObservable()", done => {
+test('$eventToObservable()', done => {
   let calls = 0
   const vm = new Vue({
-    created() {
-      this.$eventToObservable("ping").subscribe(function(event) {
-        expect(event.name).toEqual("ping")
-        expect(event.msg).toEqual("ping message")
+    created () {
+      this.$eventToObservable('ping').subscribe(function (event) {
+        expect(event.name).toEqual('ping')
+        expect(event.msg).toEqual('ping message')
         calls++
       })
     }
   })
-  vm.$emit("ping", "ping message")
+  vm.$emit('ping', 'ping message')
 
   nextTick(() => {
     vm.$destroy()
     // Should not emit
-    vm.$emit("pong", "pong message")
+    vm.$emit('pong', 'pong message')
     expect(calls).toEqual(1)
     done()
   })
 })
 
-test("$eventToObservable() with lifecycle hooks", done => {
+test('$eventToObservable() with lifecycle hooks', done => {
   const vm = new Vue({
-    created() {
-      this.$eventToObservable("hook:beforeDestroy").subscribe(() => {
+    created () {
+      this.$eventToObservable('hook:beforeDestroy').subscribe(() => {
         done()
       })
     }
@@ -410,64 +410,64 @@ test("$eventToObservable() with lifecycle hooks", done => {
   })
 })
 
-test("$createObservableMethod() with no context", done => {
+test('$createObservableMethod() with no context', done => {
   const vm = new Vue({
-    created() {
-      this.$createObservableMethod("add").subscribe(function(param) {
-        expect(param).toEqual("hola")
+    created () {
+      this.$createObservableMethod('add').subscribe(function (param) {
+        expect(param).toEqual('hola')
         done()
       })
     }
   })
   nextTick(() => {
-    vm.add("hola")
+    vm.add('hola')
   })
 })
 
-test("$createObservableMethod() with muli params & context", done => {
+test('$createObservableMethod() with muli params & context', done => {
   const vm = new Vue({
-    created() {
-      this.$createObservableMethod("add", true).subscribe(function(param) {
-        expect(param[0]).toEqual("hola")
-        expect(param[1]).toEqual("mundo")
+    created () {
+      this.$createObservableMethod('add', true).subscribe(function (param) {
+        expect(param[0]).toEqual('hola')
+        expect(param[1]).toEqual('mundo')
         expect(param[2]).toEqual(vm)
         done()
       })
     }
   })
   nextTick(() => {
-    vm.add("hola", "mundo")
+    vm.add('hola', 'mundo')
   })
 })
 
-test("observableMethods mixin", done => {
+test('observableMethods mixin', done => {
   const vm = new Vue({
-    observableMethods: ["add"],
-    created() {
-      this.add$.subscribe(function(param) {
-        expect(param[0]).toEqual("Qué")
-        expect(param[1]).toEqual("tal")
+    observableMethods: ['add'],
+    created () {
+      this.add$.subscribe(function (param) {
+        expect(param[0]).toEqual('Qué')
+        expect(param[1]).toEqual('tal')
         done()
       })
     }
   })
   nextTick(() => {
-    vm.add("Qué", "tal")
+    vm.add('Qué', 'tal')
   })
 })
 
-test("observableMethods mixin", done => {
+test('observableMethods mixin', done => {
   const vm = new Vue({
-    observableMethods: { add: "plus$" },
-    created() {
-      this.plus$.subscribe(function(param) {
-        expect(param[0]).toEqual("Qué")
-        expect(param[1]).toEqual("tal")
+    observableMethods: { add: 'plus$' },
+    created () {
+      this.plus$.subscribe(function (param) {
+        expect(param[0]).toEqual('Qué')
+        expect(param[1]).toEqual('tal')
         done()
       })
     }
   })
   nextTick(() => {
-    vm.add("Qué", "tal")
+    vm.add('Qué', 'tal')
   })
 })

--- a/test/v5.spec.js
+++ b/test/v5.spec.js
@@ -1,0 +1,533 @@
+/* eslint-env jest */
+
+'use strict'
+
+const Vue = require('vue/dist/vue.js')
+const VueRx = require('../dist/vue-rx.js')
+
+// library
+const Observable = require('rxjs-compat/Observable')
+  .Observable
+const Subject = require('rxjs-compat/Subject')
+  .Subject
+const Subscription = require('rxjs-compat/Subscription')
+  .Subscription
+require('rxjs-compat/add/observable/fromEvent')
+require('rxjs-compat/add/operator/share')
+
+// user
+require('rxjs-compat/add/operator/map')
+require('rxjs-compat/add/operator/startWith')
+require('rxjs-compat/add/operator/scan')
+require('rxjs-compat/add/operator/pluck')
+require('rxjs-compat/add/operator/merge')
+require('rxjs-compat/add/operator/filter')
+
+const miniRx = {
+  Observable,
+  Subscription,
+  Subject
+}
+
+Vue.config.productionTip = false
+Vue.use(VueRx, miniRx)
+
+const nextTick = Vue.nextTick
+
+function mock () {
+  let observer
+  const observable = Observable.create(
+    _observer => {
+      observer = _observer
+    }
+  )
+  return {
+    ob: observable,
+    next: val => observer.next(val)
+  }
+}
+
+function trigger (target, event) {
+  var e = document.createEvent('HTMLEvents')
+  e.initEvent(event, true, true)
+  target.dispatchEvent(e)
+}
+
+function click (target) {
+  trigger(target, 'click')
+}
+
+test('expose $observables', () => {
+  const { ob, next } = mock()
+
+  const vm = new Vue({
+    subscriptions: {
+      hello: ob.startWith(0)
+    }
+  })
+
+  const results = []
+  vm.$observables.hello.subscribe(val => {
+    results.push(val)
+  })
+
+  next(1)
+  next(2)
+  next(3)
+  expect(results).toEqual([0, 1, 2, 3])
+})
+
+test('bind subscriptions to render', done => {
+  const { ob, next } = mock()
+
+  const vm = new Vue({
+    subscriptions: {
+      hello: ob.startWith('foo')
+    },
+    render (h) {
+      return h('div', this.hello)
+    }
+  }).$mount()
+
+  expect(vm.$el.textContent).toBe('foo')
+
+  next('bar')
+  nextTick(() => {
+    expect(vm.$el.textContent).toBe('bar')
+    done()
+  })
+})
+
+test('subscriptions() has access to component state', () => {
+  const { ob } = mock()
+
+  const vm = new Vue({
+    data: {
+      foo: 'FOO'
+    },
+    props: ['bar'],
+    propsData: {
+      bar: 'BAR'
+    },
+    subscriptions () {
+      return {
+        hello: ob.startWith(this.foo + this.bar)
+      }
+    },
+    render (h) {
+      return h('div', this.hello)
+    }
+  }).$mount()
+
+  expect(vm.$el.textContent).toBe('FOOBAR')
+})
+
+/* I believe this is a breaking change of v6 :/
+test("subscriptions() can throw error properly", done => {
+  const { ob, next } = mock()
+
+  const vm = new Vue({
+    subscriptions() {
+      return {
+        num: ob.startWith(1).map(n => n.toFixed())
+      }
+    },
+    render(h) {
+      return h("div", this.num)
+    }
+  }).$mount()
+
+  nextTick(() => {
+    expect(() => {
+      next(null)
+    }).toThrow()
+    expect(vm.$el.textContent).toBe("1")
+    done()
+  })
+})
+*/
+
+test('v-stream directive (basic)', done => {
+  const vm = new Vue({
+    template: `
+      <div>
+        <span class="count">{{ count }}</span>
+        <button v-stream:click="click$">+</button>
+      </div>
+    `,
+    domStreams: ['click$'],
+    subscriptions () {
+      return {
+        count: this.click$
+          .map(() => 1)
+          .startWith(0)
+          .scan((total, change) => total + change)
+      }
+    }
+  }).$mount()
+
+  expect(
+    vm.$el.querySelector('span').textContent
+  ).toBe('0')
+  click(vm.$el.querySelector('button'))
+  nextTick(() => {
+    expect(
+      vm.$el.querySelector('span').textContent
+    ).toBe('1')
+    done()
+  })
+})
+
+test('v-stream directive (with .native modify)', done => {
+  const vm = new Vue({
+    template: `
+      <div>
+        <span class="count">{{ count }}</span>
+        <my-button id="btn-native" v-stream:click.native="clickNative$">+</my-button>
+        <my-button id="btn" v-stream:click="click$">-</my-button>
+      </div>
+    `,
+    components: {
+      myButton: {
+        template: '<button>MyButton</button>'
+      }
+    },
+    domStreams: ['clickNative$', 'click$'],
+    subscriptions () {
+      return {
+        count: this.clickNative$
+          .merge(this.click$)
+          .filter(
+            e =>
+              e.event.target &&
+              e.event.target.id === 'btn-native'
+          )
+          .map(() => 1)
+          .startWith(0)
+          .scan((total, change) => total + change)
+      }
+    }
+  }).$mount()
+
+  expect(
+    vm.$el.querySelector('span').textContent
+  ).toBe('0')
+  click(vm.$el.querySelector('#btn'))
+  click(vm.$el.querySelector('#btn'))
+  click(vm.$el.querySelector('#btn-native'))
+  nextTick(() => {
+    expect(
+      vm.$el.querySelector('span').textContent
+    ).toBe('1')
+    done()
+  })
+})
+
+test('v-stream directive (with .stop, .prevent modify)', done => {
+  const vm = new Vue({
+    template: `
+      <form>
+        <span>{{stoped}} {{prevented}}</span>
+        <button id="btn-stop" v-stream:click.stop="clickStop$">Stop</button>
+        <button id="btn-prevent" type="submit" v-stream:click.prevent="clickPrevent$">Submit</button>
+      </form>
+    `,
+    domStreams: ['clickStop$', 'clickPrevent$'],
+    subscriptions () {
+      return {
+        stoped: this.clickStop$.map(
+          x => x.event.cancelBubble
+        ),
+        prevented: this.clickPrevent$.map(
+          x => x.event.defaultPrevented
+        )
+      }
+    }
+  }).$mount()
+
+  click(vm.$el.querySelector('#btn-stop'))
+  click(vm.$el.querySelector('#btn-prevent'))
+  nextTick(() => {
+    expect(
+      vm.$el.querySelector('span').textContent
+    ).toBe('true true')
+    done()
+  })
+})
+
+test('v-stream directive (with data)', done => {
+  const vm = new Vue({
+    data: {
+      delta: -1
+    },
+    template: `
+      <div>
+        <span class="count">{{ count }}</span>
+        <button v-stream:click="{ subject: click$, data: delta }">+</button>
+      </div>
+    `,
+    domStreams: ['click$'],
+    subscriptions () {
+      return {
+        count: this.click$
+          .pluck('data')
+          .startWith(0)
+          .scan((total, change) => total + change)
+      }
+    }
+  }).$mount()
+
+  expect(
+    vm.$el.querySelector('span').textContent
+  ).toBe('0')
+  click(vm.$el.querySelector('button'))
+  nextTick(() => {
+    expect(
+      vm.$el.querySelector('span').textContent
+    ).toBe('-1')
+    vm.delta = 1
+    nextTick(() => {
+      click(vm.$el.querySelector('button'))
+      nextTick(() => {
+        expect(
+          vm.$el.querySelector('span').textContent
+        ).toBe('0')
+        done()
+      })
+    })
+  })
+})
+
+test('v-stream directive (multiple bindings on same node)', done => {
+  const vm = new Vue({
+    template: `
+      <div>
+        <span class="count">{{ count }}</span>
+        <button
+          v-stream:click="{ subject: plus$, data: 1 }"
+          v-stream:keyup="{ subject: plus$, data: -1 }">+</button>
+      </div>
+    `,
+    domStreams: ['plus$'],
+    subscriptions () {
+      return {
+        count: this.plus$
+          .pluck('data')
+          .startWith(0)
+          .scan((total, change) => total + change)
+      }
+    }
+  }).$mount()
+
+  expect(
+    vm.$el.querySelector('span').textContent
+  ).toBe('0')
+  click(vm.$el.querySelector('button'))
+  nextTick(() => {
+    expect(
+      vm.$el.querySelector('span').textContent
+    ).toBe('1')
+    trigger(
+      vm.$el.querySelector('button'),
+      'keyup'
+    )
+    nextTick(() => {
+      expect(
+        vm.$el.querySelector('span').textContent
+      ).toBe('0')
+      done()
+    })
+  })
+})
+
+test('$fromDOMEvent()', done => {
+  const vm = new Vue({
+    template: `
+      <div>
+        <span class="count">{{ count }}</span>
+        <button>+</button>
+      </div>
+    `,
+    subscriptions () {
+      const click$ = this.$fromDOMEvent(
+        'button',
+        'click'
+      )
+      return {
+        count: click$
+          .map(() => 1)
+          .startWith(0)
+          .scan((total, change) => total + change)
+      }
+    }
+  }).$mount()
+
+  document.body.appendChild(vm.$el)
+  expect(
+    vm.$el.querySelector('span').textContent
+  ).toBe('0')
+  click(vm.$el.querySelector('button'))
+  nextTick(() => {
+    expect(
+      vm.$el.querySelector('span').textContent
+    ).toBe('1')
+    done()
+  })
+})
+
+test('$watchAsObservable()', done => {
+  const vm = new Vue({
+    data: {
+      count: 0
+    }
+  })
+
+  const results = []
+  vm
+    .$watchAsObservable('count')
+    .subscribe(change => {
+      results.push(change)
+    })
+
+  vm.count++
+  nextTick(() => {
+    expect(results).toEqual([
+      { newValue: 1, oldValue: 0 }
+    ])
+    vm.count++
+    nextTick(() => {
+      expect(results).toEqual([
+        { newValue: 1, oldValue: 0 },
+        { newValue: 2, oldValue: 1 }
+      ])
+      done()
+    })
+  })
+})
+
+test('$subscribeTo()', () => {
+  const { ob, next } = mock()
+  const results = []
+  const vm = new Vue({
+    created () {
+      this.$subscribeTo(ob, count => {
+        results.push(count)
+      })
+    }
+  })
+
+  next(1)
+  expect(results).toEqual([1])
+
+  vm.$destroy()
+  next(2)
+  expect(results).toEqual([1]) // should not trigger anymore
+})
+
+test('$eventToObservable()', done => {
+  let calls = 0
+  const vm = new Vue({
+    created () {
+      this.$eventToObservable('ping').subscribe(
+        function (event) {
+          expect(event.name).toEqual('ping')
+          expect(event.msg).toEqual(
+            'ping message'
+          )
+          calls++
+        }
+      )
+    }
+  })
+  vm.$emit('ping', 'ping message')
+
+  nextTick(() => {
+    vm.$destroy()
+    // Should not emit
+    vm.$emit('pong', 'pong message')
+    expect(calls).toEqual(1)
+    done()
+  })
+})
+
+test('$eventToObservable() with lifecycle hooks', done => {
+  const vm = new Vue({
+    created () {
+      this.$eventToObservable(
+        'hook:beforeDestroy'
+      ).subscribe(() => {
+        done()
+      })
+    }
+  })
+  nextTick(() => {
+    vm.$destroy()
+  })
+})
+
+test('$createObservableMethod() with no context', done => {
+  const vm = new Vue({
+    created () {
+      this.$createObservableMethod(
+        'add'
+      ).subscribe(function (param) {
+        expect(param).toEqual('hola')
+        done()
+      })
+    }
+  })
+  nextTick(() => {
+    vm.add('hola')
+  })
+})
+
+test('$createObservableMethod() with muli params & context', done => {
+  const vm = new Vue({
+    created () {
+      this.$createObservableMethod(
+        'add',
+        true
+      ).subscribe(function (param) {
+        expect(param[0]).toEqual('hola')
+        expect(param[1]).toEqual('mundo')
+        expect(param[2]).toEqual(vm)
+        done()
+      })
+    }
+  })
+  nextTick(() => {
+    vm.add('hola', 'mundo')
+  })
+})
+
+test('observableMethods mixin', done => {
+  const vm = new Vue({
+    observableMethods: ['add'],
+    created () {
+      this.add$.subscribe(function (param) {
+        expect(param[0]).toEqual('Qué')
+        expect(param[1]).toEqual('tal')
+        done()
+      })
+    }
+  })
+  nextTick(() => {
+    vm.add('Qué', 'tal')
+  })
+})
+
+test('observableMethods mixin', done => {
+  const vm = new Vue({
+    observableMethods: { add: 'plus$' },
+    created () {
+      this.plus$.subscribe(function (param) {
+        expect(param[0]).toEqual('Qué')
+        expect(param[1]).toEqual('tal')
+        done()
+      })
+    }
+  })
+  nextTick(() => {
+    vm.add('Qué', 'tal')
+  })
+})

--- a/test/v5.spec.js
+++ b/test/v5.spec.js
@@ -1,27 +1,24 @@
 /* eslint-env jest */
 
-'use strict'
+"use strict"
 
-const Vue = require('vue/dist/vue.js')
-const VueRx = require('../dist/vue-rx.js')
+const Vue = require("vue/dist/vue.js")
+const VueRx = require("../dist/vue-rx.js")
 
 // library
-const Observable = require('rxjs-compat/Observable')
-  .Observable
-const Subject = require('rxjs-compat/Subject')
-  .Subject
-const Subscription = require('rxjs-compat/Subscription')
-  .Subscription
-require('rxjs-compat/add/observable/fromEvent')
-require('rxjs-compat/add/operator/share')
+const Observable = require("rxjs-compat/Observable").Observable
+const Subject = require("rxjs-compat/Subject").Subject
+const Subscription = require("rxjs-compat/Subscription").Subscription
+require("rxjs-compat/add/observable/fromEvent")
+require("rxjs-compat/add/operator/share")
 
 // user
-require('rxjs-compat/add/operator/map')
-require('rxjs-compat/add/operator/startWith')
-require('rxjs-compat/add/operator/scan')
-require('rxjs-compat/add/operator/pluck')
-require('rxjs-compat/add/operator/merge')
-require('rxjs-compat/add/operator/filter')
+require("rxjs-compat/add/operator/map")
+require("rxjs-compat/add/operator/startWith")
+require("rxjs-compat/add/operator/scan")
+require("rxjs-compat/add/operator/pluck")
+require("rxjs-compat/add/operator/merge")
+require("rxjs-compat/add/operator/filter")
 
 const miniRx = {
   Observable,
@@ -34,30 +31,28 @@ Vue.use(VueRx, miniRx)
 
 const nextTick = Vue.nextTick
 
-function mock () {
+function mock() {
   let observer
-  const observable = Observable.create(
-    _observer => {
-      observer = _observer
-    }
-  )
+  const observable = Observable.create(_observer => {
+    observer = _observer
+  })
   return {
     ob: observable,
     next: val => observer.next(val)
   }
 }
 
-function trigger (target, event) {
-  var e = document.createEvent('HTMLEvents')
+function trigger(target, event) {
+  var e = document.createEvent("HTMLEvents")
   e.initEvent(event, true, true)
   target.dispatchEvent(e)
 }
 
-function click (target) {
-  trigger(target, 'click')
+function click(target) {
+  trigger(target, "click")
 }
 
-test('expose $observables', () => {
+test("expose $observables", () => {
   const { ob, next } = mock()
 
   const vm = new Vue({
@@ -77,49 +72,49 @@ test('expose $observables', () => {
   expect(results).toEqual([0, 1, 2, 3])
 })
 
-test('bind subscriptions to render', done => {
+test("bind subscriptions to render", done => {
   const { ob, next } = mock()
 
   const vm = new Vue({
     subscriptions: {
-      hello: ob.startWith('foo')
+      hello: ob.startWith("foo")
     },
-    render (h) {
-      return h('div', this.hello)
+    render(h) {
+      return h("div", this.hello)
     }
   }).$mount()
 
-  expect(vm.$el.textContent).toBe('foo')
+  expect(vm.$el.textContent).toBe("foo")
 
-  next('bar')
+  next("bar")
   nextTick(() => {
-    expect(vm.$el.textContent).toBe('bar')
+    expect(vm.$el.textContent).toBe("bar")
     done()
   })
 })
 
-test('subscriptions() has access to component state', () => {
+test("subscriptions() has access to component state", () => {
   const { ob } = mock()
 
   const vm = new Vue({
     data: {
-      foo: 'FOO'
+      foo: "FOO"
     },
-    props: ['bar'],
+    props: ["bar"],
     propsData: {
-      bar: 'BAR'
+      bar: "BAR"
     },
-    subscriptions () {
+    subscriptions() {
       return {
         hello: ob.startWith(this.foo + this.bar)
       }
     },
-    render (h) {
-      return h('div', this.hello)
+    render(h) {
+      return h("div", this.hello)
     }
   }).$mount()
 
-  expect(vm.$el.textContent).toBe('FOOBAR')
+  expect(vm.$el.textContent).toBe("FOOBAR")
 })
 
 /* I believe this is a breaking change of v6 :/
@@ -147,7 +142,7 @@ test("subscriptions() can throw error properly", done => {
 })
 */
 
-test('v-stream directive (basic)', done => {
+test("v-stream directive (basic)", done => {
   const vm = new Vue({
     template: `
       <div>
@@ -155,8 +150,8 @@ test('v-stream directive (basic)', done => {
         <button v-stream:click="click$">+</button>
       </div>
     `,
-    domStreams: ['click$'],
-    subscriptions () {
+    domStreams: ["click$"],
+    subscriptions() {
       return {
         count: this.click$
           .map(() => 1)
@@ -166,19 +161,15 @@ test('v-stream directive (basic)', done => {
     }
   }).$mount()
 
-  expect(
-    vm.$el.querySelector('span').textContent
-  ).toBe('0')
-  click(vm.$el.querySelector('button'))
+  expect(vm.$el.querySelector("span").textContent).toBe("0")
+  click(vm.$el.querySelector("button"))
   nextTick(() => {
-    expect(
-      vm.$el.querySelector('span').textContent
-    ).toBe('1')
+    expect(vm.$el.querySelector("span").textContent).toBe("1")
     done()
   })
 })
 
-test('v-stream directive (with .native modify)', done => {
+test("v-stream directive (with .native modify)", done => {
   const vm = new Vue({
     template: `
       <div>
@@ -189,19 +180,15 @@ test('v-stream directive (with .native modify)', done => {
     `,
     components: {
       myButton: {
-        template: '<button>MyButton</button>'
+        template: "<button>MyButton</button>"
       }
     },
-    domStreams: ['clickNative$', 'click$'],
-    subscriptions () {
+    domStreams: ["clickNative$", "click$"],
+    subscriptions() {
       return {
         count: this.clickNative$
           .merge(this.click$)
-          .filter(
-            e =>
-              e.event.target &&
-              e.event.target.id === 'btn-native'
-          )
+          .filter(e => e.event.target && e.event.target.id === "btn-native")
           .map(() => 1)
           .startWith(0)
           .scan((total, change) => total + change)
@@ -209,21 +196,17 @@ test('v-stream directive (with .native modify)', done => {
     }
   }).$mount()
 
-  expect(
-    vm.$el.querySelector('span').textContent
-  ).toBe('0')
-  click(vm.$el.querySelector('#btn'))
-  click(vm.$el.querySelector('#btn'))
-  click(vm.$el.querySelector('#btn-native'))
+  expect(vm.$el.querySelector("span").textContent).toBe("0")
+  click(vm.$el.querySelector("#btn"))
+  click(vm.$el.querySelector("#btn"))
+  click(vm.$el.querySelector("#btn-native"))
   nextTick(() => {
-    expect(
-      vm.$el.querySelector('span').textContent
-    ).toBe('1')
+    expect(vm.$el.querySelector("span").textContent).toBe("1")
     done()
   })
 })
 
-test('v-stream directive (with .stop, .prevent modify)', done => {
+test("v-stream directive (with .stop, .prevent modify)", done => {
   const vm = new Vue({
     template: `
       <form>
@@ -232,30 +215,24 @@ test('v-stream directive (with .stop, .prevent modify)', done => {
         <button id="btn-prevent" type="submit" v-stream:click.prevent="clickPrevent$">Submit</button>
       </form>
     `,
-    domStreams: ['clickStop$', 'clickPrevent$'],
-    subscriptions () {
+    domStreams: ["clickStop$", "clickPrevent$"],
+    subscriptions() {
       return {
-        stoped: this.clickStop$.map(
-          x => x.event.cancelBubble
-        ),
-        prevented: this.clickPrevent$.map(
-          x => x.event.defaultPrevented
-        )
+        stoped: this.clickStop$.map(x => x.event.cancelBubble),
+        prevented: this.clickPrevent$.map(x => x.event.defaultPrevented)
       }
     }
   }).$mount()
 
-  click(vm.$el.querySelector('#btn-stop'))
-  click(vm.$el.querySelector('#btn-prevent'))
+  click(vm.$el.querySelector("#btn-stop"))
+  click(vm.$el.querySelector("#btn-prevent"))
   nextTick(() => {
-    expect(
-      vm.$el.querySelector('span').textContent
-    ).toBe('true true')
+    expect(vm.$el.querySelector("span").textContent).toBe("true true")
     done()
   })
 })
 
-test('v-stream directive (with data)', done => {
+test("v-stream directive (with data)", done => {
   const vm = new Vue({
     data: {
       delta: -1
@@ -266,39 +243,33 @@ test('v-stream directive (with data)', done => {
         <button v-stream:click="{ subject: click$, data: delta }">+</button>
       </div>
     `,
-    domStreams: ['click$'],
-    subscriptions () {
+    domStreams: ["click$"],
+    subscriptions() {
       return {
         count: this.click$
-          .pluck('data')
+          .pluck("data")
           .startWith(0)
           .scan((total, change) => total + change)
       }
     }
   }).$mount()
 
-  expect(
-    vm.$el.querySelector('span').textContent
-  ).toBe('0')
-  click(vm.$el.querySelector('button'))
+  expect(vm.$el.querySelector("span").textContent).toBe("0")
+  click(vm.$el.querySelector("button"))
   nextTick(() => {
-    expect(
-      vm.$el.querySelector('span').textContent
-    ).toBe('-1')
+    expect(vm.$el.querySelector("span").textContent).toBe("-1")
     vm.delta = 1
     nextTick(() => {
-      click(vm.$el.querySelector('button'))
+      click(vm.$el.querySelector("button"))
       nextTick(() => {
-        expect(
-          vm.$el.querySelector('span').textContent
-        ).toBe('0')
+        expect(vm.$el.querySelector("span").textContent).toBe("0")
         done()
       })
     })
   })
 })
 
-test('v-stream directive (multiple bindings on same node)', done => {
+test("v-stream directive (multiple bindings on same node)", done => {
   const vm = new Vue({
     template: `
       <div>
@@ -308,39 +279,30 @@ test('v-stream directive (multiple bindings on same node)', done => {
           v-stream:keyup="{ subject: plus$, data: -1 }">+</button>
       </div>
     `,
-    domStreams: ['plus$'],
-    subscriptions () {
+    domStreams: ["plus$"],
+    subscriptions() {
       return {
         count: this.plus$
-          .pluck('data')
+          .pluck("data")
           .startWith(0)
           .scan((total, change) => total + change)
       }
     }
   }).$mount()
 
-  expect(
-    vm.$el.querySelector('span').textContent
-  ).toBe('0')
-  click(vm.$el.querySelector('button'))
+  expect(vm.$el.querySelector("span").textContent).toBe("0")
+  click(vm.$el.querySelector("button"))
   nextTick(() => {
-    expect(
-      vm.$el.querySelector('span').textContent
-    ).toBe('1')
-    trigger(
-      vm.$el.querySelector('button'),
-      'keyup'
-    )
+    expect(vm.$el.querySelector("span").textContent).toBe("1")
+    trigger(vm.$el.querySelector("button"), "keyup")
     nextTick(() => {
-      expect(
-        vm.$el.querySelector('span').textContent
-      ).toBe('0')
+      expect(vm.$el.querySelector("span").textContent).toBe("0")
       done()
     })
   })
 })
 
-test('$fromDOMEvent()', done => {
+test("$fromDOMEvent()", done => {
   const vm = new Vue({
     template: `
       <div>
@@ -348,11 +310,8 @@ test('$fromDOMEvent()', done => {
         <button>+</button>
       </div>
     `,
-    subscriptions () {
-      const click$ = this.$fromDOMEvent(
-        'button',
-        'click'
-      )
+    subscriptions() {
+      const click$ = this.$fromDOMEvent("button", "click")
       return {
         count: click$
           .map(() => 1)
@@ -363,19 +322,15 @@ test('$fromDOMEvent()', done => {
   }).$mount()
 
   document.body.appendChild(vm.$el)
-  expect(
-    vm.$el.querySelector('span').textContent
-  ).toBe('0')
-  click(vm.$el.querySelector('button'))
+  expect(vm.$el.querySelector("span").textContent).toBe("0")
+  click(vm.$el.querySelector("button"))
   nextTick(() => {
-    expect(
-      vm.$el.querySelector('span').textContent
-    ).toBe('1')
+    expect(vm.$el.querySelector("span").textContent).toBe("1")
     done()
   })
 })
 
-test('$watchAsObservable()', done => {
+test("$watchAsObservable()", done => {
   const vm = new Vue({
     data: {
       count: 0
@@ -383,17 +338,13 @@ test('$watchAsObservable()', done => {
   })
 
   const results = []
-  vm
-    .$watchAsObservable('count')
-    .subscribe(change => {
-      results.push(change)
-    })
+  vm.$watchAsObservable("count").subscribe(change => {
+    results.push(change)
+  })
 
   vm.count++
   nextTick(() => {
-    expect(results).toEqual([
-      { newValue: 1, oldValue: 0 }
-    ])
+    expect(results).toEqual([{ newValue: 1, oldValue: 0 }])
     vm.count++
     nextTick(() => {
       expect(results).toEqual([
@@ -405,11 +356,11 @@ test('$watchAsObservable()', done => {
   })
 })
 
-test('$subscribeTo()', () => {
+test("$subscribeTo()", () => {
   const { ob, next } = mock()
   const results = []
   const vm = new Vue({
-    created () {
+    created() {
       this.$subscribeTo(ob, count => {
         results.push(count)
       })
@@ -424,38 +375,32 @@ test('$subscribeTo()', () => {
   expect(results).toEqual([1]) // should not trigger anymore
 })
 
-test('$eventToObservable()', done => {
+test("$eventToObservable()", done => {
   let calls = 0
   const vm = new Vue({
-    created () {
-      this.$eventToObservable('ping').subscribe(
-        function (event) {
-          expect(event.name).toEqual('ping')
-          expect(event.msg).toEqual(
-            'ping message'
-          )
-          calls++
-        }
-      )
+    created() {
+      this.$eventToObservable("ping").subscribe(function(event) {
+        expect(event.name).toEqual("ping")
+        expect(event.msg).toEqual("ping message")
+        calls++
+      })
     }
   })
-  vm.$emit('ping', 'ping message')
+  vm.$emit("ping", "ping message")
 
   nextTick(() => {
     vm.$destroy()
     // Should not emit
-    vm.$emit('pong', 'pong message')
+    vm.$emit("pong", "pong message")
     expect(calls).toEqual(1)
     done()
   })
 })
 
-test('$eventToObservable() with lifecycle hooks', done => {
+test("$eventToObservable() with lifecycle hooks", done => {
   const vm = new Vue({
-    created () {
-      this.$eventToObservable(
-        'hook:beforeDestroy'
-      ).subscribe(() => {
+    created() {
+      this.$eventToObservable("hook:beforeDestroy").subscribe(() => {
         done()
       })
     }
@@ -465,69 +410,64 @@ test('$eventToObservable() with lifecycle hooks', done => {
   })
 })
 
-test('$createObservableMethod() with no context', done => {
+test("$createObservableMethod() with no context", done => {
   const vm = new Vue({
-    created () {
-      this.$createObservableMethod(
-        'add'
-      ).subscribe(function (param) {
-        expect(param).toEqual('hola')
+    created() {
+      this.$createObservableMethod("add").subscribe(function(param) {
+        expect(param).toEqual("hola")
         done()
       })
     }
   })
   nextTick(() => {
-    vm.add('hola')
+    vm.add("hola")
   })
 })
 
-test('$createObservableMethod() with muli params & context', done => {
+test("$createObservableMethod() with muli params & context", done => {
   const vm = new Vue({
-    created () {
-      this.$createObservableMethod(
-        'add',
-        true
-      ).subscribe(function (param) {
-        expect(param[0]).toEqual('hola')
-        expect(param[1]).toEqual('mundo')
+    created() {
+      this.$createObservableMethod("add", true).subscribe(function(param) {
+        expect(param[0]).toEqual("hola")
+        expect(param[1]).toEqual("mundo")
         expect(param[2]).toEqual(vm)
         done()
       })
     }
   })
   nextTick(() => {
-    vm.add('hola', 'mundo')
+    vm.add("hola", "mundo")
   })
 })
 
-test('observableMethods mixin', done => {
+test("observableMethods mixin", done => {
   const vm = new Vue({
-    observableMethods: ['add'],
-    created () {
-      this.add$.subscribe(function (param) {
-        expect(param[0]).toEqual('Qué')
-        expect(param[1]).toEqual('tal')
+    observableMethods: ["add"],
+    created() {
+      this.add$.subscribe(function(param) {
+        expect(param[0]).toEqual("Qué")
+        expect(param[1]).toEqual("tal")
         done()
       })
     }
   })
   nextTick(() => {
-    vm.add('Qué', 'tal')
+    vm.add("Qué", "tal")
   })
 })
 
-test('observableMethods mixin', done => {
+test("observableMethods mixin", done => {
   const vm = new Vue({
-    observableMethods: { add: 'plus$' },
-    created () {
-      this.plus$.subscribe(function (param) {
-        expect(param[0]).toEqual('Qué')
-        expect(param[1]).toEqual('tal')
+    observableMethods: { add: "plus$" },
+    created() {
+      this.plus$.subscribe(function(param) {
+        expect(param[0]).toEqual("Qué")
+        expect(param[1]).toEqual("tal")
         done()
       })
     }
   })
   nextTick(() => {
-    vm.add('Qué', 'tal')
+    vm.add("Qué", "tal")
   })
 })

--- a/test/v6.spec.js
+++ b/test/v6.spec.js
@@ -1,13 +1,13 @@
 /* eslint-env jest */
 
-"use strict"
+'use strict'
 
-const Vue = require("vue/dist/vue.js")
-const VueRx = require("../dist/vue-rx.js")
+const Vue = require('vue/dist/vue.js')
+const VueRx = require('../dist/vue-rx.js')
 
-const { Observable, Subscription, Subject, fromEvent, merge } = require("rxjs")
+const { Observable, Subscription, Subject, fromEvent, merge } = require('rxjs')
 
-const { filter, map, pluck, scan, share, startWith } = require("rxjs/operators")
+const { filter, map, pluck, scan, share, startWith } = require('rxjs/operators')
 
 const miniRx = {
   Observable,
@@ -21,7 +21,7 @@ Vue.use(VueRx, miniRx)
 
 const nextTick = Vue.nextTick
 
-function mock() {
+function mock () {
   let observer
   const observable = Observable.create(_observer => {
     observer = _observer
@@ -32,17 +32,17 @@ function mock() {
   }
 }
 
-function trigger(target, event) {
-  var e = document.createEvent("HTMLEvents")
+function trigger (target, event) {
+  var e = document.createEvent('HTMLEvents')
   e.initEvent(event, true, true)
   target.dispatchEvent(e)
 }
 
-function click(target) {
-  trigger(target, "click")
+function click (target) {
+  trigger(target, 'click')
 }
 
-test("expose $observables", () => {
+test('expose $observables', () => {
   const { ob, next } = mock()
 
   const vm = new Vue({
@@ -62,49 +62,49 @@ test("expose $observables", () => {
   expect(results).toEqual([0, 1, 2, 3])
 })
 
-test("bind subscriptions to render", done => {
+test('bind subscriptions to render', done => {
   const { ob, next } = mock()
 
   const vm = new Vue({
     subscriptions: {
-      hello: ob.pipe(startWith("foo"))
+      hello: ob.pipe(startWith('foo'))
     },
-    render(h) {
-      return h("div", this.hello)
+    render (h) {
+      return h('div', this.hello)
     }
   }).$mount()
 
-  expect(vm.$el.textContent).toBe("foo")
+  expect(vm.$el.textContent).toBe('foo')
 
-  next("bar")
+  next('bar')
   nextTick(() => {
-    expect(vm.$el.textContent).toBe("bar")
+    expect(vm.$el.textContent).toBe('bar')
     done()
   })
 })
 
-test("subscriptions() has access to component state", () => {
+test('subscriptions() has access to component state', () => {
   const { ob } = mock()
 
   const vm = new Vue({
     data: {
-      foo: "FOO"
+      foo: 'FOO'
     },
-    props: ["bar"],
+    props: ['bar'],
     propsData: {
-      bar: "BAR"
+      bar: 'BAR'
     },
-    subscriptions() {
+    subscriptions () {
       return {
         hello: ob.pipe(startWith(this.foo + this.bar))
       }
     },
-    render(h) {
-      return h("div", this.hello)
+    render (h) {
+      return h('div', this.hello)
     }
   }).$mount()
 
-  expect(vm.$el.textContent).toBe("FOOBAR")
+  expect(vm.$el.textContent).toBe('FOOBAR')
 })
 
 /*
@@ -132,7 +132,7 @@ test("subscriptions() can throw error properly", done => {
 })
 */
 
-test("v-stream directive (basic)", done => {
+test('v-stream directive (basic)', done => {
   const vm = new Vue({
     template: `
       <div>
@@ -140,8 +140,8 @@ test("v-stream directive (basic)", done => {
         <button v-stream:click="click$">+</button>
       </div>
     `,
-    domStreams: ["click$"],
-    subscriptions() {
+    domStreams: ['click$'],
+    subscriptions () {
       return {
         count: this.click$.pipe(
           map(() => 1),
@@ -152,15 +152,15 @@ test("v-stream directive (basic)", done => {
     }
   }).$mount()
 
-  expect(vm.$el.querySelector("span").textContent).toBe("0")
-  click(vm.$el.querySelector("button"))
+  expect(vm.$el.querySelector('span').textContent).toBe('0')
+  click(vm.$el.querySelector('button'))
   nextTick(() => {
-    expect(vm.$el.querySelector("span").textContent).toBe("1")
+    expect(vm.$el.querySelector('span').textContent).toBe('1')
     done()
   })
 })
 
-test("v-stream directive (with .native modify)", done => {
+test('v-stream directive (with .native modify)', done => {
   const vm = new Vue({
     template: `
       <div>
@@ -171,14 +171,14 @@ test("v-stream directive (with .native modify)", done => {
     `,
     components: {
       myButton: {
-        template: "<button>MyButton</button>"
+        template: '<button>MyButton</button>'
       }
     },
-    domStreams: ["clickNative$", "click$"],
-    subscriptions() {
+    domStreams: ['clickNative$', 'click$'],
+    subscriptions () {
       return {
         count: merge(this.clickNative$, this.click$).pipe(
-          filter(e => e.event.target && e.event.target.id === "btn-native"),
+          filter(e => e.event.target && e.event.target.id === 'btn-native'),
           map(() => 1),
           startWith(0),
           scan((total, change) => total + change)
@@ -187,17 +187,17 @@ test("v-stream directive (with .native modify)", done => {
     }
   }).$mount()
 
-  expect(vm.$el.querySelector("span").textContent).toBe("0")
-  click(vm.$el.querySelector("#btn"))
-  click(vm.$el.querySelector("#btn"))
-  click(vm.$el.querySelector("#btn-native"))
+  expect(vm.$el.querySelector('span').textContent).toBe('0')
+  click(vm.$el.querySelector('#btn'))
+  click(vm.$el.querySelector('#btn'))
+  click(vm.$el.querySelector('#btn-native'))
   nextTick(() => {
-    expect(vm.$el.querySelector("span").textContent).toBe("1")
+    expect(vm.$el.querySelector('span').textContent).toBe('1')
     done()
   })
 })
 
-test("v-stream directive (with .stop, .prevent modify)", done => {
+test('v-stream directive (with .stop, .prevent modify)', done => {
   const vm = new Vue({
     template: `
       <form>
@@ -206,8 +206,8 @@ test("v-stream directive (with .stop, .prevent modify)", done => {
         <button id="btn-prevent" type="submit" v-stream:click.prevent="clickPrevent$">Submit</button>
       </form>
     `,
-    domStreams: ["clickStop$", "clickPrevent$"],
-    subscriptions() {
+    domStreams: ['clickStop$', 'clickPrevent$'],
+    subscriptions () {
       return {
         stopped: this.clickStop$.pipe(map(x => x.event.cancelBubble)),
         prevented: this.clickPrevent$.pipe(map(x => x.event.defaultPrevented))
@@ -215,15 +215,15 @@ test("v-stream directive (with .stop, .prevent modify)", done => {
     }
   }).$mount()
 
-  click(vm.$el.querySelector("#btn-stop"))
-  click(vm.$el.querySelector("#btn-prevent"))
+  click(vm.$el.querySelector('#btn-stop'))
+  click(vm.$el.querySelector('#btn-prevent'))
   nextTick(() => {
-    expect(vm.$el.querySelector("span").textContent).toBe("true true")
+    expect(vm.$el.querySelector('span').textContent).toBe('true true')
     done()
   })
 })
 
-test("v-stream directive (with data)", done => {
+test('v-stream directive (with data)', done => {
   const vm = new Vue({
     data: {
       delta: -1
@@ -234,11 +234,11 @@ test("v-stream directive (with data)", done => {
         <button v-stream:click="{ subject: click$, data: delta }">+</button>
       </div>
     `,
-    domStreams: ["click$"],
-    subscriptions() {
+    domStreams: ['click$'],
+    subscriptions () {
       return {
         count: this.click$.pipe(
-          pluck("data"),
+          pluck('data'),
           startWith(0),
           scan((total, change) => total + change)
         )
@@ -246,22 +246,22 @@ test("v-stream directive (with data)", done => {
     }
   }).$mount()
 
-  expect(vm.$el.querySelector("span").textContent).toBe("0")
-  click(vm.$el.querySelector("button"))
+  expect(vm.$el.querySelector('span').textContent).toBe('0')
+  click(vm.$el.querySelector('button'))
   nextTick(() => {
-    expect(vm.$el.querySelector("span").textContent).toBe("-1")
+    expect(vm.$el.querySelector('span').textContent).toBe('-1')
     vm.delta = 1
     nextTick(() => {
-      click(vm.$el.querySelector("button"))
+      click(vm.$el.querySelector('button'))
       nextTick(() => {
-        expect(vm.$el.querySelector("span").textContent).toBe("0")
+        expect(vm.$el.querySelector('span').textContent).toBe('0')
         done()
       })
     })
   })
 })
 
-test("v-stream directive (multiple bindings on same node)", done => {
+test('v-stream directive (multiple bindings on same node)', done => {
   const vm = new Vue({
     template: `
       <div>
@@ -271,11 +271,11 @@ test("v-stream directive (multiple bindings on same node)", done => {
           v-stream:keyup="{ subject: plus$, data: -1 }">+</button>
       </div>
     `,
-    domStreams: ["plus$"],
-    subscriptions() {
+    domStreams: ['plus$'],
+    subscriptions () {
       return {
         count: this.plus$.pipe(
-          pluck("data"),
+          pluck('data'),
           startWith(0),
           scan((total, change) => total + change)
         )
@@ -283,19 +283,19 @@ test("v-stream directive (multiple bindings on same node)", done => {
     }
   }).$mount()
 
-  expect(vm.$el.querySelector("span").textContent).toBe("0")
-  click(vm.$el.querySelector("button"))
+  expect(vm.$el.querySelector('span').textContent).toBe('0')
+  click(vm.$el.querySelector('button'))
   nextTick(() => {
-    expect(vm.$el.querySelector("span").textContent).toBe("1")
-    trigger(vm.$el.querySelector("button"), "keyup")
+    expect(vm.$el.querySelector('span').textContent).toBe('1')
+    trigger(vm.$el.querySelector('button'), 'keyup')
     nextTick(() => {
-      expect(vm.$el.querySelector("span").textContent).toBe("0")
+      expect(vm.$el.querySelector('span').textContent).toBe('0')
       done()
     })
   })
 })
 
-test("$fromDOMEvent()", done => {
+test('$fromDOMEvent()', done => {
   const vm = new Vue({
     template: `
       <div>
@@ -303,8 +303,8 @@ test("$fromDOMEvent()", done => {
         <button>+</button>
       </div>
     `,
-    subscriptions() {
-      const click$ = this.$fromDOMEvent("button", "click")
+    subscriptions () {
+      const click$ = this.$fromDOMEvent('button', 'click')
       return {
         count: click$.pipe(
           map(() => 1),
@@ -316,15 +316,15 @@ test("$fromDOMEvent()", done => {
   }).$mount()
 
   document.body.appendChild(vm.$el)
-  expect(vm.$el.querySelector("span").textContent).toBe("0")
-  click(vm.$el.querySelector("button"))
+  expect(vm.$el.querySelector('span').textContent).toBe('0')
+  click(vm.$el.querySelector('button'))
   nextTick(() => {
-    expect(vm.$el.querySelector("span").textContent).toBe("1")
+    expect(vm.$el.querySelector('span').textContent).toBe('1')
     done()
   })
 })
 
-test("$watchAsObservable()", done => {
+test('$watchAsObservable()', done => {
   const vm = new Vue({
     data: {
       count: 0
@@ -332,7 +332,7 @@ test("$watchAsObservable()", done => {
   })
 
   const results = []
-  vm.$watchAsObservable("count").subscribe(change => {
+  vm.$watchAsObservable('count').subscribe(change => {
     results.push(change)
   })
 
@@ -350,11 +350,11 @@ test("$watchAsObservable()", done => {
   })
 })
 
-test("$subscribeTo()", () => {
+test('$subscribeTo()', () => {
   const { ob, next } = mock()
   const results = []
   const vm = new Vue({
-    created() {
+    created () {
       this.$subscribeTo(ob, count => {
         results.push(count)
       })
@@ -369,32 +369,32 @@ test("$subscribeTo()", () => {
   expect(results).toEqual([1]) // should not trigger anymore
 })
 
-test("$eventToObservable()", done => {
+test('$eventToObservable()', done => {
   let calls = 0
   const vm = new Vue({
-    created() {
-      this.$eventToObservable("ping").subscribe(function(event) {
-        expect(event.name).toEqual("ping")
-        expect(event.msg).toEqual("ping message")
+    created () {
+      this.$eventToObservable('ping').subscribe(function (event) {
+        expect(event.name).toEqual('ping')
+        expect(event.msg).toEqual('ping message')
         calls++
       })
     }
   })
-  vm.$emit("ping", "ping message")
+  vm.$emit('ping', 'ping message')
 
   nextTick(() => {
     vm.$destroy()
     // Should not emit
-    vm.$emit("pong", "pong message")
+    vm.$emit('pong', 'pong message')
     expect(calls).toEqual(1)
     done()
   })
 })
 
-test("$eventToObservable() with lifecycle hooks", done => {
+test('$eventToObservable() with lifecycle hooks', done => {
   const vm = new Vue({
-    created() {
-      this.$eventToObservable("hook:beforeDestroy").subscribe(() => {
+    created () {
+      this.$eventToObservable('hook:beforeDestroy').subscribe(() => {
         done()
       })
     }
@@ -404,64 +404,64 @@ test("$eventToObservable() with lifecycle hooks", done => {
   })
 })
 
-test("$createObservableMethod() with no context", done => {
+test('$createObservableMethod() with no context', done => {
   const vm = new Vue({
-    created() {
-      this.$createObservableMethod("add").subscribe(function(param) {
-        expect(param).toEqual("hola")
+    created () {
+      this.$createObservableMethod('add').subscribe(function (param) {
+        expect(param).toEqual('hola')
         done()
       })
     }
   })
   nextTick(() => {
-    vm.add("hola")
+    vm.add('hola')
   })
 })
 
-test("$createObservableMethod() with multi params & context", done => {
+test('$createObservableMethod() with multi params & context', done => {
   const vm = new Vue({
-    created() {
-      this.$createObservableMethod("add", true).subscribe(function(param) {
-        expect(param[0]).toEqual("hola")
-        expect(param[1]).toEqual("mundo")
+    created () {
+      this.$createObservableMethod('add', true).subscribe(function (param) {
+        expect(param[0]).toEqual('hola')
+        expect(param[1]).toEqual('mundo')
         expect(param[2]).toEqual(vm)
         done()
       })
     }
   })
   nextTick(() => {
-    vm.add("hola", "mundo")
+    vm.add('hola', 'mundo')
   })
 })
 
-test("observableMethods mixin", done => {
+test('observableMethods mixin', done => {
   const vm = new Vue({
-    observableMethods: ["add"],
-    created() {
-      this.add$.subscribe(function(param) {
-        expect(param[0]).toEqual("Qué")
-        expect(param[1]).toEqual("tal")
+    observableMethods: ['add'],
+    created () {
+      this.add$.subscribe(function (param) {
+        expect(param[0]).toEqual('Qué')
+        expect(param[1]).toEqual('tal')
         done()
       })
     }
   })
   nextTick(() => {
-    vm.add("Qué", "tal")
+    vm.add('Qué', 'tal')
   })
 })
 
-test("observableMethods mixin", done => {
+test('observableMethods mixin', done => {
   const vm = new Vue({
-    observableMethods: { add: "plus$" },
-    created() {
-      this.plus$.subscribe(function(param) {
-        expect(param[0]).toEqual("Qué")
-        expect(param[1]).toEqual("tal")
+    observableMethods: { add: 'plus$' },
+    created () {
+      this.plus$.subscribe(function (param) {
+        expect(param[0]).toEqual('Qué')
+        expect(param[1]).toEqual('tal')
         done()
       })
     }
   })
   nextTick(() => {
-    vm.add("Qué", "tal")
+    vm.add('Qué', 'tal')
   })
 })

--- a/test/v6.spec.js
+++ b/test/v6.spec.js
@@ -1,26 +1,13 @@
 /* eslint-env jest */
 
-'use strict'
+"use strict"
 
-const Vue = require('vue/dist/vue.js')
-const VueRx = require('../dist/vue-rx.js')
+const Vue = require("vue/dist/vue.js")
+const VueRx = require("../dist/vue-rx.js")
 
-const {
-  Observable,
-  Subscription,
-  Subject,
-  fromEvent,
-  merge
-} = require('rxjs')
+const { Observable, Subscription, Subject, fromEvent, merge } = require("rxjs")
 
-const {
-  filter,
-  map,
-  pluck,
-  scan,
-  share,
-  startWith
-} = require('rxjs/operators')
+const { filter, map, pluck, scan, share, startWith } = require("rxjs/operators")
 
 const miniRx = {
   Observable,
@@ -34,30 +21,28 @@ Vue.use(VueRx, miniRx)
 
 const nextTick = Vue.nextTick
 
-function mock () {
+function mock() {
   let observer
-  const observable = Observable.create(
-    _observer => {
-      observer = _observer
-    }
-  )
+  const observable = Observable.create(_observer => {
+    observer = _observer
+  })
   return {
     ob: observable,
     next: val => observer.next(val)
   }
 }
 
-function trigger (target, event) {
-  var e = document.createEvent('HTMLEvents')
+function trigger(target, event) {
+  var e = document.createEvent("HTMLEvents")
   e.initEvent(event, true, true)
   target.dispatchEvent(e)
 }
 
-function click (target) {
-  trigger(target, 'click')
+function click(target) {
+  trigger(target, "click")
 }
 
-test('expose $observables', () => {
+test("expose $observables", () => {
   const { ob, next } = mock()
 
   const vm = new Vue({
@@ -77,51 +62,49 @@ test('expose $observables', () => {
   expect(results).toEqual([0, 1, 2, 3])
 })
 
-test('bind subscriptions to render', done => {
+test("bind subscriptions to render", done => {
   const { ob, next } = mock()
 
   const vm = new Vue({
     subscriptions: {
-      hello: ob.pipe(startWith('foo'))
+      hello: ob.pipe(startWith("foo"))
     },
-    render (h) {
-      return h('div', this.hello)
+    render(h) {
+      return h("div", this.hello)
     }
   }).$mount()
 
-  expect(vm.$el.textContent).toBe('foo')
+  expect(vm.$el.textContent).toBe("foo")
 
-  next('bar')
+  next("bar")
   nextTick(() => {
-    expect(vm.$el.textContent).toBe('bar')
+    expect(vm.$el.textContent).toBe("bar")
     done()
   })
 })
 
-test('subscriptions() has access to component state', () => {
+test("subscriptions() has access to component state", () => {
   const { ob } = mock()
 
   const vm = new Vue({
     data: {
-      foo: 'FOO'
+      foo: "FOO"
     },
-    props: ['bar'],
+    props: ["bar"],
     propsData: {
-      bar: 'BAR'
+      bar: "BAR"
     },
-    subscriptions () {
+    subscriptions() {
       return {
-        hello: ob.pipe(
-          startWith(this.foo + this.bar)
-        )
+        hello: ob.pipe(startWith(this.foo + this.bar))
       }
     },
-    render (h) {
-      return h('div', this.hello)
+    render(h) {
+      return h("div", this.hello)
     }
   }).$mount()
 
-  expect(vm.$el.textContent).toBe('FOOBAR')
+  expect(vm.$el.textContent).toBe("FOOBAR")
 })
 
 /*
@@ -149,7 +132,7 @@ test("subscriptions() can throw error properly", done => {
 })
 */
 
-test('v-stream directive (basic)', done => {
+test("v-stream directive (basic)", done => {
   const vm = new Vue({
     template: `
       <div>
@@ -157,8 +140,8 @@ test('v-stream directive (basic)', done => {
         <button v-stream:click="click$">+</button>
       </div>
     `,
-    domStreams: ['click$'],
-    subscriptions () {
+    domStreams: ["click$"],
+    subscriptions() {
       return {
         count: this.click$.pipe(
           map(() => 1),
@@ -169,19 +152,15 @@ test('v-stream directive (basic)', done => {
     }
   }).$mount()
 
-  expect(
-    vm.$el.querySelector('span').textContent
-  ).toBe('0')
-  click(vm.$el.querySelector('button'))
+  expect(vm.$el.querySelector("span").textContent).toBe("0")
+  click(vm.$el.querySelector("button"))
   nextTick(() => {
-    expect(
-      vm.$el.querySelector('span').textContent
-    ).toBe('1')
+    expect(vm.$el.querySelector("span").textContent).toBe("1")
     done()
   })
 })
 
-test('v-stream directive (with .native modify)', done => {
+test("v-stream directive (with .native modify)", done => {
   const vm = new Vue({
     template: `
       <div>
@@ -192,21 +171,14 @@ test('v-stream directive (with .native modify)', done => {
     `,
     components: {
       myButton: {
-        template: '<button>MyButton</button>'
+        template: "<button>MyButton</button>"
       }
     },
-    domStreams: ['clickNative$', 'click$'],
-    subscriptions () {
+    domStreams: ["clickNative$", "click$"],
+    subscriptions() {
       return {
-        count: merge(
-          this.clickNative$,
-          this.click$
-        ).pipe(
-          filter(
-            e =>
-              e.event.target &&
-              e.event.target.id === 'btn-native'
-          ),
+        count: merge(this.clickNative$, this.click$).pipe(
+          filter(e => e.event.target && e.event.target.id === "btn-native"),
           map(() => 1),
           startWith(0),
           scan((total, change) => total + change)
@@ -215,21 +187,17 @@ test('v-stream directive (with .native modify)', done => {
     }
   }).$mount()
 
-  expect(
-    vm.$el.querySelector('span').textContent
-  ).toBe('0')
-  click(vm.$el.querySelector('#btn'))
-  click(vm.$el.querySelector('#btn'))
-  click(vm.$el.querySelector('#btn-native'))
+  expect(vm.$el.querySelector("span").textContent).toBe("0")
+  click(vm.$el.querySelector("#btn"))
+  click(vm.$el.querySelector("#btn"))
+  click(vm.$el.querySelector("#btn-native"))
   nextTick(() => {
-    expect(
-      vm.$el.querySelector('span').textContent
-    ).toBe('1')
+    expect(vm.$el.querySelector("span").textContent).toBe("1")
     done()
   })
 })
 
-test('v-stream directive (with .stop, .prevent modify)', done => {
+test("v-stream directive (with .stop, .prevent modify)", done => {
   const vm = new Vue({
     template: `
       <form>
@@ -238,30 +206,24 @@ test('v-stream directive (with .stop, .prevent modify)', done => {
         <button id="btn-prevent" type="submit" v-stream:click.prevent="clickPrevent$">Submit</button>
       </form>
     `,
-    domStreams: ['clickStop$', 'clickPrevent$'],
-    subscriptions () {
+    domStreams: ["clickStop$", "clickPrevent$"],
+    subscriptions() {
       return {
-        stopped: this.clickStop$.pipe(
-          map(x => x.event.cancelBubble)
-        ),
-        prevented: this.clickPrevent$.pipe(
-          map(x => x.event.defaultPrevented)
-        )
+        stopped: this.clickStop$.pipe(map(x => x.event.cancelBubble)),
+        prevented: this.clickPrevent$.pipe(map(x => x.event.defaultPrevented))
       }
     }
   }).$mount()
 
-  click(vm.$el.querySelector('#btn-stop'))
-  click(vm.$el.querySelector('#btn-prevent'))
+  click(vm.$el.querySelector("#btn-stop"))
+  click(vm.$el.querySelector("#btn-prevent"))
   nextTick(() => {
-    expect(
-      vm.$el.querySelector('span').textContent
-    ).toBe('true true')
+    expect(vm.$el.querySelector("span").textContent).toBe("true true")
     done()
   })
 })
 
-test('v-stream directive (with data)', done => {
+test("v-stream directive (with data)", done => {
   const vm = new Vue({
     data: {
       delta: -1
@@ -272,11 +234,11 @@ test('v-stream directive (with data)', done => {
         <button v-stream:click="{ subject: click$, data: delta }">+</button>
       </div>
     `,
-    domStreams: ['click$'],
-    subscriptions () {
+    domStreams: ["click$"],
+    subscriptions() {
       return {
         count: this.click$.pipe(
-          pluck('data'),
+          pluck("data"),
           startWith(0),
           scan((total, change) => total + change)
         )
@@ -284,28 +246,22 @@ test('v-stream directive (with data)', done => {
     }
   }).$mount()
 
-  expect(
-    vm.$el.querySelector('span').textContent
-  ).toBe('0')
-  click(vm.$el.querySelector('button'))
+  expect(vm.$el.querySelector("span").textContent).toBe("0")
+  click(vm.$el.querySelector("button"))
   nextTick(() => {
-    expect(
-      vm.$el.querySelector('span').textContent
-    ).toBe('-1')
+    expect(vm.$el.querySelector("span").textContent).toBe("-1")
     vm.delta = 1
     nextTick(() => {
-      click(vm.$el.querySelector('button'))
+      click(vm.$el.querySelector("button"))
       nextTick(() => {
-        expect(
-          vm.$el.querySelector('span').textContent
-        ).toBe('0')
+        expect(vm.$el.querySelector("span").textContent).toBe("0")
         done()
       })
     })
   })
 })
 
-test('v-stream directive (multiple bindings on same node)', done => {
+test("v-stream directive (multiple bindings on same node)", done => {
   const vm = new Vue({
     template: `
       <div>
@@ -315,11 +271,11 @@ test('v-stream directive (multiple bindings on same node)', done => {
           v-stream:keyup="{ subject: plus$, data: -1 }">+</button>
       </div>
     `,
-    domStreams: ['plus$'],
-    subscriptions () {
+    domStreams: ["plus$"],
+    subscriptions() {
       return {
         count: this.plus$.pipe(
-          pluck('data'),
+          pluck("data"),
           startWith(0),
           scan((total, change) => total + change)
         )
@@ -327,28 +283,19 @@ test('v-stream directive (multiple bindings on same node)', done => {
     }
   }).$mount()
 
-  expect(
-    vm.$el.querySelector('span').textContent
-  ).toBe('0')
-  click(vm.$el.querySelector('button'))
+  expect(vm.$el.querySelector("span").textContent).toBe("0")
+  click(vm.$el.querySelector("button"))
   nextTick(() => {
-    expect(
-      vm.$el.querySelector('span').textContent
-    ).toBe('1')
-    trigger(
-      vm.$el.querySelector('button'),
-      'keyup'
-    )
+    expect(vm.$el.querySelector("span").textContent).toBe("1")
+    trigger(vm.$el.querySelector("button"), "keyup")
     nextTick(() => {
-      expect(
-        vm.$el.querySelector('span').textContent
-      ).toBe('0')
+      expect(vm.$el.querySelector("span").textContent).toBe("0")
       done()
     })
   })
 })
 
-test('$fromDOMEvent()', done => {
+test("$fromDOMEvent()", done => {
   const vm = new Vue({
     template: `
       <div>
@@ -356,11 +303,8 @@ test('$fromDOMEvent()', done => {
         <button>+</button>
       </div>
     `,
-    subscriptions () {
-      const click$ = this.$fromDOMEvent(
-        'button',
-        'click'
-      )
+    subscriptions() {
+      const click$ = this.$fromDOMEvent("button", "click")
       return {
         count: click$.pipe(
           map(() => 1),
@@ -372,19 +316,15 @@ test('$fromDOMEvent()', done => {
   }).$mount()
 
   document.body.appendChild(vm.$el)
-  expect(
-    vm.$el.querySelector('span').textContent
-  ).toBe('0')
-  click(vm.$el.querySelector('button'))
+  expect(vm.$el.querySelector("span").textContent).toBe("0")
+  click(vm.$el.querySelector("button"))
   nextTick(() => {
-    expect(
-      vm.$el.querySelector('span').textContent
-    ).toBe('1')
+    expect(vm.$el.querySelector("span").textContent).toBe("1")
     done()
   })
 })
 
-test('$watchAsObservable()', done => {
+test("$watchAsObservable()", done => {
   const vm = new Vue({
     data: {
       count: 0
@@ -392,17 +332,13 @@ test('$watchAsObservable()', done => {
   })
 
   const results = []
-  vm
-    .$watchAsObservable('count')
-    .subscribe(change => {
-      results.push(change)
-    })
+  vm.$watchAsObservable("count").subscribe(change => {
+    results.push(change)
+  })
 
   vm.count++
   nextTick(() => {
-    expect(results).toEqual([
-      { newValue: 1, oldValue: 0 }
-    ])
+    expect(results).toEqual([{ newValue: 1, oldValue: 0 }])
     vm.count++
     nextTick(() => {
       expect(results).toEqual([
@@ -414,11 +350,11 @@ test('$watchAsObservable()', done => {
   })
 })
 
-test('$subscribeTo()', () => {
+test("$subscribeTo()", () => {
   const { ob, next } = mock()
   const results = []
   const vm = new Vue({
-    created () {
+    created() {
       this.$subscribeTo(ob, count => {
         results.push(count)
       })
@@ -433,38 +369,32 @@ test('$subscribeTo()', () => {
   expect(results).toEqual([1]) // should not trigger anymore
 })
 
-test('$eventToObservable()', done => {
+test("$eventToObservable()", done => {
   let calls = 0
   const vm = new Vue({
-    created () {
-      this.$eventToObservable('ping').subscribe(
-        function (event) {
-          expect(event.name).toEqual('ping')
-          expect(event.msg).toEqual(
-            'ping message'
-          )
-          calls++
-        }
-      )
+    created() {
+      this.$eventToObservable("ping").subscribe(function(event) {
+        expect(event.name).toEqual("ping")
+        expect(event.msg).toEqual("ping message")
+        calls++
+      })
     }
   })
-  vm.$emit('ping', 'ping message')
+  vm.$emit("ping", "ping message")
 
   nextTick(() => {
     vm.$destroy()
     // Should not emit
-    vm.$emit('pong', 'pong message')
+    vm.$emit("pong", "pong message")
     expect(calls).toEqual(1)
     done()
   })
 })
 
-test('$eventToObservable() with lifecycle hooks', done => {
+test("$eventToObservable() with lifecycle hooks", done => {
   const vm = new Vue({
-    created () {
-      this.$eventToObservable(
-        'hook:beforeDestroy'
-      ).subscribe(() => {
+    created() {
+      this.$eventToObservable("hook:beforeDestroy").subscribe(() => {
         done()
       })
     }
@@ -474,69 +404,64 @@ test('$eventToObservable() with lifecycle hooks', done => {
   })
 })
 
-test('$createObservableMethod() with no context', done => {
+test("$createObservableMethod() with no context", done => {
   const vm = new Vue({
-    created () {
-      this.$createObservableMethod(
-        'add'
-      ).subscribe(function (param) {
-        expect(param).toEqual('hola')
+    created() {
+      this.$createObservableMethod("add").subscribe(function(param) {
+        expect(param).toEqual("hola")
         done()
       })
     }
   })
   nextTick(() => {
-    vm.add('hola')
+    vm.add("hola")
   })
 })
 
-test('$createObservableMethod() with multi params & context', done => {
+test("$createObservableMethod() with multi params & context", done => {
   const vm = new Vue({
-    created () {
-      this.$createObservableMethod(
-        'add',
-        true
-      ).subscribe(function (param) {
-        expect(param[0]).toEqual('hola')
-        expect(param[1]).toEqual('mundo')
+    created() {
+      this.$createObservableMethod("add", true).subscribe(function(param) {
+        expect(param[0]).toEqual("hola")
+        expect(param[1]).toEqual("mundo")
         expect(param[2]).toEqual(vm)
         done()
       })
     }
   })
   nextTick(() => {
-    vm.add('hola', 'mundo')
+    vm.add("hola", "mundo")
   })
 })
 
-test('observableMethods mixin', done => {
+test("observableMethods mixin", done => {
   const vm = new Vue({
-    observableMethods: ['add'],
-    created () {
-      this.add$.subscribe(function (param) {
-        expect(param[0]).toEqual('Qué')
-        expect(param[1]).toEqual('tal')
+    observableMethods: ["add"],
+    created() {
+      this.add$.subscribe(function(param) {
+        expect(param[0]).toEqual("Qué")
+        expect(param[1]).toEqual("tal")
         done()
       })
     }
   })
   nextTick(() => {
-    vm.add('Qué', 'tal')
+    vm.add("Qué", "tal")
   })
 })
 
-test('observableMethods mixin', done => {
+test("observableMethods mixin", done => {
   const vm = new Vue({
-    observableMethods: { add: 'plus$' },
-    created () {
-      this.plus$.subscribe(function (param) {
-        expect(param[0]).toEqual('Qué')
-        expect(param[1]).toEqual('tal')
+    observableMethods: { add: "plus$" },
+    created() {
+      this.plus$.subscribe(function(param) {
+        expect(param[0]).toEqual("Qué")
+        expect(param[1]).toEqual("tal")
         done()
       })
     }
   })
   nextTick(() => {
-    vm.add('Qué', 'tal')
+    vm.add("Qué", "tal")
   })
 })

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -2,15 +2,9 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es5",
-    "lib": [
-      "es5",
-      "dom",
-      "es2015.promise"
-    ],
+    "lib": ["es5", "dom", "es2015.iterable", "es2015.promise", "es2015.symbol"],
     "strict": true,
     "noEmit": true
   },
-  "include": [
-    "*.d.ts"
-  ]
+  "include": ["*.d.ts"]
 }

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -2,9 +2,17 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es5",
-    "lib": ["es5", "dom", "es2015.iterable", "es2015.promise", "es2015.symbol"],
+    "lib": [
+      "es5",
+      "dom",
+      "es2015.promise",
+      "es2015.iterable",
+      "es2015.symbol"
+    ],
     "strict": true,
     "noEmit": true
   },
-  "include": ["*.d.ts"]
+  "include": [
+    "*.d.ts"
+  ]
 }


### PR DESCRIPTION
RxJS v6 now uses a "pipeable" operators paradigm thus changing how `fromEvent` and `share` are required when installing.

### Plugin Installation API
API-wise: 
`Vue.use(VueRx, {Observable, Subject, Subscription})`
now requires `fromEvent` and `share`
`Vue.use(VueRx, {Observable, Subject, Subscription, fromEvent, share})`

`stream.js` and `createObservableMethod.js` were updated to support either API.

### Tests
* Tests were separated into `v5.test.js` and `v6.test.js`.
* `v5` now uses `rxjs-compat` for backwards compatibility. 
** Note a small breaking change with errors: https://twitter.com/johnlindquist/status/979408339858845704
* `v6` are the same tests, but using `rxjs` and "pipeable" operators