### PR TITLE
Updated typings to include default export

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -31,4 +31,4 @@ declare module "vue/types/vue" {
   }
 }
 
-export declare function install(V: typeof Vue): void
+export default function VueRx(V: typeof Vue): void

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue'
-import * as VueRX from '../index'
+import VueRX from '../index'
 import { interval }from 'rxjs'
 import { pluck, map } from 'rxjs/operators'
 


### PR DESCRIPTION
Closes #89 

This modifies the *typings* so that package `'vue-rx'`:
1. now exports `VueRx` by default
2. no longer exports `install`, which wasn't actually being exported anyway

VueRx should now be able to be imported as mentioned in the [npm section of the README](https://github.com/vuejs/vue-rx#npm--es2015):
```ts
import Vue from 'vue'
import VueRx from 'vue-rx'

Vue.use(VueRx)
```