### PR TITLE
test(v-stream): ensure the data gets passed correctly also on custom component

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -232,48 +232,10 @@ test('v-stream directive (with .stop, .prevent modify)', done => {
   })
 })
 
-test('v-stream directive on native element (with data)', done => {
-  const vm = new Vue({
-    data: {
-      delta: -1
-    },
-    template: `
-      <div>
-        <span class="count">{{ count }}</span>
-        <button v-stream:click="{ subject: click$, data: delta }">+</button>
-      </div>
-    `,
-    domStreams: ['click$'],
-    subscriptions () {
-      return {
-        count: this.click$.pipe(
-          pluck('data'),
-          startWith(0),
-          scan((total, change) => total + change),
-        )
-      }
-    }
-  }).$mount()
-
-  expect(vm.$el.querySelector('span').textContent).toBe('0')
-  click(vm.$el.querySelector('button'))
-  nextTick(() => {
-    expect(vm.$el.querySelector('span').textContent).toBe('-1')
-    vm.delta = 1
-    nextTick(() => {
-      click(vm.$el.querySelector('button'))
-      nextTick(() => {
-        expect(vm.$el.querySelector('span').textContent).toBe('0')
-        done()
-      })
-    })
-  })
-})
-
-test('v-stream directive on custom component (with data)', done => {
+test('v-stream directive (with data)', done => {
   const customButton = {
     name: 'custom-button',
-    template: `<button @click="$emit('click')"><slot/></button>`
+    template: `<button id="custom-button" @click="$emit('click')"><slot/></button>`
   }
 
   const vm = new Vue({
@@ -286,6 +248,7 @@ test('v-stream directive on custom component (with data)', done => {
     template: `
       <div>
         <span class="count">{{ count }}</span>
+        <button id="native-button" v-stream:click="{ subject: click$, data: delta }">+</button>
         <custom-button v-stream:click="{ subject: click$, data: delta }">+</custom-button>
       </div>
     `,
@@ -302,12 +265,12 @@ test('v-stream directive on custom component (with data)', done => {
   }).$mount()
 
   expect(vm.$el.querySelector('span').textContent).toBe('0')
-  click(vm.$el.querySelector('button'))
+  click(vm.$el.querySelector('#custom-button'))
   nextTick(() => {
     expect(vm.$el.querySelector('span').textContent).toBe('-1')
     vm.delta = 1
     nextTick(() => {
-      click(vm.$el.querySelector('button'))
+      click(vm.$el.querySelector('#native-button'))
       nextTick(() => {
         expect(vm.$el.querySelector('span').textContent).toBe('0')
         done()

--- a/test/test.js
+++ b/test/test.js
@@ -235,7 +235,7 @@ test('v-stream directive (with .stop, .prevent modify)', done => {
 test('v-stream directive (with data)', done => {
   const customButton = {
     name: 'custom-button',
-    template: `<button id="custom-button" @click="$emit('click')"><slot/></button>`
+    template: `<button id="custom-button" @click="$emit('click-custom')"><slot/></button>`
   }
 
   const vm = new Vue({
@@ -249,7 +249,7 @@ test('v-stream directive (with data)', done => {
       <div>
         <span class="count">{{ count }}</span>
         <button id="native-button" v-stream:click="{ subject: click$, data: delta }">+</button>
-        <custom-button v-stream:click="{ subject: click$, data: delta }">+</custom-button>
+        <custom-button v-stream:click-custom="{ subject: click$, data: delta }">+</custom-button>
       </div>
     `,
     domStreams: ['click$'],


### PR DESCRIPTION
Hello. I saw a fix for #106, and I just thought that it could have been prevented by a test case so that similar problems won't happen again. What I did was just modifying the current test case for `v-stream` with data so that it also tests custom component instead of just a native element. 

Also, just curious, why isn't the test using [`vue-test-utils`](https://github.com/vuejs/vue-test-utils)? Is it because it's still in beta? I don't mind doing the refactor if it should be the way to go.

Let me know what you think. Thanks.