### PR TITLE
Fix: If subscribeTo is called before the $options.subscriptions is pr…

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -30,7 +30,7 @@ export default {
     }
     if (obs) {
       vm.$observables = {}
-      vm._subscription = new Subscription()
+      vm._subscription = (vm._subscription || new Subscription())
       Object.keys(obs).forEach(key => {
         defineReactive(vm, key, undefined)
         const ob = vm.$observables[key] = obs[key]


### PR DESCRIPTION
Fix: If subscribeTo is called before the $options.subscriptions is processed, the Subscriptions object is overwritten and the subscribed observables are not cleaned up when the component is destroyed.
The fix is simple: it just doesn't reinstatiate this._subscription if it already exists.